### PR TITLE
Refactor: remove hard-coded margin in FormPanel

### DIFF
--- a/src/main/java/ca/corbett/forms/FormPanel.java
+++ b/src/main/java/ca/corbett/forms/FormPanel.java
@@ -13,25 +13,33 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * FormPanel wraps a collection of FormFields and manages the following functions:
+ * FormPanel wraps a collection of FormFields and manages the following
+ * functions:
  * <ul>
- *     <li><b>Layout management</b> - you don't need to write manual GridBagLayout code
- *         to use a FormPanel. Just add your FormFields to the panel and the layout will
- *         be handled automatically.
- *     <li><b>Form validation</b> - assuming you've added FieldValidator instances to
- *         your FormFields as needed, you don't need to write much manual validation code,
- *         and you don't need to write any UI code to show validation results. Just
- *         call formField.validate() and the validators will be invoked automatically.
- *     <li><b>Optional inline help</b> - every FormField can have optional help text
- *         which the FormPanel will render inline in the form of an information icon
- *         next to the field, which will show tooltip help text.
- *     <li><b>Generic FormField handling</b> - the FormField class is highly
- *         extensible, so you can very easily provide your own FormField implementation
- *         for custom display and editing of data.
+ * <li><b>Layout management</b> - you don't need to write manual GridBagLayout
+ * code
+ * to use a FormPanel. Just add your FormFields to the panel and the layout will
+ * be handled automatically.
+ * <li><b>Form validation</b> - assuming you've added FieldValidator instances
+ * to
+ * your FormFields as needed, you don't need to write much manual validation
+ * code,
+ * and you don't need to write any UI code to show validation results. Just
+ * call formField.validate() and the validators will be invoked automatically.
+ * <li><b>Optional inline help</b> - every FormField can have optional help text
+ * which the FormPanel will render inline in the form of an information icon
+ * next to the field, which will show tooltip help text.
+ * <li><b>Generic FormField handling</b> - the FormField class is highly
+ * extensible, so you can very easily provide your own FormField implementation
+ * for custom display and editing of data.
  * </ul>
  *
- * <p>Handling oversized forms</p><br>
- * You can easily add a FormPanel to a JScrollPane to provide for scrollbars in the
+ * <p>
+ * Handling oversized forms
+ * </p>
+ * <br>
+ * You can easily add a FormPanel to a JScrollPane to provide for scrollbars in
+ * the
  * case where the form is unreasonably large.
  *
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
@@ -51,6 +59,7 @@ public final class FormPanel extends JPanel {
     private Alignment alignment;
     private final Margins formPanelMargins = new Margins(0);
     private boolean renderInProgress = false;
+    private int multiLineTopMargin = 4;
 
     /**
      * Creates a new, empty FormPanel with TOP_CENTER Alignment.
@@ -67,14 +76,20 @@ public final class FormPanel extends JPanel {
     }
 
     /**
-     * An optional pixel margin for the FormPanel itself to keep it away from the edges
+     * An optional pixel margin for the FormPanel itself to keep it away from the
+     * edges
      * of its container. The default value is zero, meaning no extra margins will
-     * be applied. Note that any value given here is added to whatever margins are already present on
-     * each individual FormField. This value does not replace those values. So, you can still indent
-     * a FormField from the others by setting its left margin on a left-aligned form, even if the
-     * FormPanel itself already specifies a left margin. The two values are added together in that case.
+     * be applied. Note that any value given here is added to whatever margins are
+     * already present on
+     * each individual FormField. This value does not replace those values. So, you
+     * can still indent
+     * a FormField from the others by setting its left margin on a left-aligned
+     * form, even if the
+     * FormPanel itself already specifies a left margin. The two values are added
+     * together in that case.
      *
-     * @param margin The margin, in pixels, to apply to the FormPanel. Negative values are treated as 0.
+     * @param margin The margin, in pixels, to apply to the FormPanel. Negative
+     *               values are treated as 0.
      */
     public FormPanel setBorderMargin(int margin) {
         formPanelMargins.setAll(margin);
@@ -82,15 +97,22 @@ public final class FormPanel extends JPanel {
     }
 
     /**
-     * Sets optional pixel margins for the FormPanel itself to keep it away from the edges
+     * Sets optional pixel margins for the FormPanel itself to keep it away from the
+     * edges
      * of its container. The default value is zero, meaning no extra margins will
-     * be applied. Note that any value given here is added to whatever margins are already present on
-     * each individual FormField. This value does not replace those values. So, you can still indent
-     * a FormField from the others by setting its left margin on a left-aligned form, even if the
-     * FormPanel itself already specifies a left margin. The two values are added together in that case.
+     * be applied. Note that any value given here is added to whatever margins are
+     * already present on
+     * each individual FormField. This value does not replace those values. So, you
+     * can still indent
+     * a FormField from the others by setting its left margin on a left-aligned
+     * form, even if the
+     * FormPanel itself already specifies a left margin. The two values are added
+     * together in that case.
      * <p>
-     * <b>Note:</b> the Margins class defines an internalSpacing property. That property is ignored
-     * for FormPanel margin calculations. We only care about top, left, bottom, and right.
+     * <b>Note:</b> the Margins class defines an internalSpacing property. That
+     * property is ignored
+     * for FormPanel margin calculations. We only care about top, left, bottom, and
+     * right.
      * </p>
      */
     public FormPanel setBorderMargin(Margins margins) {
@@ -99,7 +121,8 @@ public final class FormPanel extends JPanel {
     }
 
     /**
-     * Returns the optional border margin to be applied as described in setBorderMargin.
+     * Returns the optional border margin to be applied as described in
+     * setBorderMargin.
      * The actual instance is returned, so callers can modify individual properties.
      */
     public Margins getBorderMargin() {
@@ -107,8 +130,20 @@ public final class FormPanel extends JPanel {
     }
 
     /**
+     * Sets the top margin to be applied to multi-line form fields.
+     * The default value is 4 pixels.
+     *
+     * @param margin The margin in pixels.
+     */
+    public FormPanel setMultiLineTopMargin(int margin) {
+        this.multiLineTopMargin = margin;
+        return this;
+    }
+
+    /**
      * Returns a copy of the list of FormFields contained in this panel.
-     * A copy of the list is returned to avoid client modification of the list itself.
+     * A copy of the list is returned to avoid client modification of the list
+     * itself.
      *
      * @return A copy of the list of form fields for this form panel.
      */
@@ -152,7 +187,8 @@ public final class FormPanel extends JPanel {
     public void removeAll() {
         super.removeAll();
         if (!renderInProgress) {
-            removeAllFormFields(); // don't invoke if this call came from our own render() method, else infinite loop
+            removeAllFormFields(); // don't invoke if this call came from our own render() method, else infinite
+                                   // loop
         }
     }
 
@@ -204,8 +240,10 @@ public final class FormPanel extends JPanel {
     }
 
     /**
-     * Validates each FormField by invoking all FieldValidators that are attached to it,
-     * then returns the overall result. The return will be true if all FieldValidators for
+     * Validates each FormField by invoking all FieldValidators that are attached to
+     * it,
+     * then returns the overall result. The return will be true if all
+     * FieldValidators for
      * all FormFields validated successfully.
      */
     public boolean isFormValid() {
@@ -241,9 +279,12 @@ public final class FormPanel extends JPanel {
     }
 
     /**
-     * If it is required to re-render the form panel for some reason, you can do it manually here.
-     * Generally, this should not be necessary, as a re-render will happen automatically as fields
-     * are added or removed. But, if a field has changed structurally in some way that requires
+     * If it is required to re-render the form panel for some reason, you can do it
+     * manually here.
+     * Generally, this should not be necessary, as a re-render will happen
+     * automatically as fields
+     * are added or removed. But, if a field has changed structurally in some way
+     * that requires
      * a re-render, this option exists.
      */
     public void forceRerender() {
@@ -259,7 +300,8 @@ public final class FormPanel extends JPanel {
     }
 
     /**
-     * Invoked internally as needed to remove all UI components and re-do the form layout.
+     * Invoked internally as needed to remove all UI components and re-do the form
+     * layout.
      */
     private void render() {
         renderInProgress = true;
@@ -291,7 +333,8 @@ public final class FormPanel extends JPanel {
     }
 
     /**
-     * Invoked internally to render the field label for the given FormField, if it has one.
+     * Invoked internally to render the field label for the given FormField, if it
+     * has one.
      */
     private void renderFieldLabel(FormField field, int row, Margins margins) {
         if (!field.hasFieldLabel()) {
@@ -302,30 +345,32 @@ public final class FormPanel extends JPanel {
         constraints.gridx = FORM_FIELD_START_COLUMN;
         constraints.gridy = row;
         constraints.anchor = field.isMultiLine() ? GridBagConstraints.FIRST_LINE_START : GridBagConstraints.WEST;
-        int extraTopMargin = field.isMultiLine() ? 4 : 0; // TODO don't hard-code this value
+        int extraTopMargin = field.isMultiLine() ? multiLineTopMargin : 0; // TODO don't hard-code this value
         constraints.insets = new Insets(margins.getTop() + extraTopMargin,
-                                        margins.getLeft(),
-                                        margins.getBottom(),
-                                        margins.getInternalSpacing());
+                margins.getLeft(),
+                margins.getBottom(),
+                margins.getInternalSpacing());
         add(field.getFieldLabel(), constraints);
     }
 
     /**
-     * Invoked internally to render the field component for the given FormField, if it has one.
+     * Invoked internally to render the field component for the given FormField, if
+     * it has one.
      */
     private void renderFieldComponent(FormField field, int row, Margins margins) {
         if (field.getFieldComponent() == null) {
             return;
         }
 
-        // If a field label exists, then left margin has already been set. Otherwise, set it now.
+        // If a field label exists, then left margin has already been set. Otherwise,
+        // set it now.
         int leftMargin = field.hasFieldLabel() ? margins.getInternalSpacing() : margins.getLeft();
 
         GridBagConstraints constraints = new GridBagConstraints();
         constraints.insets = new Insets(margins.getTop(),
-                                        leftMargin,
-                                        margins.getBottom(),
-                                        margins.getInternalSpacing());
+                leftMargin,
+                margins.getBottom(),
+                margins.getInternalSpacing());
         constraints.gridx = CONTROL_COLUMN;
         constraints.gridy = row;
         constraints.anchor = field.isMultiLine() ? GridBagConstraints.NORTHWEST : GridBagConstraints.WEST;
@@ -345,7 +390,8 @@ public final class FormPanel extends JPanel {
     }
 
     /**
-     * Invoked internally to render the help label for the given FormField, if it has one.
+     * Invoked internally to render the help label for the given FormField, if it
+     * has one.
      */
     private void renderHelpLabel(FormField field, int row, Margins margins) {
         if (!field.hasHelpLabel()) {
@@ -357,25 +403,27 @@ public final class FormPanel extends JPanel {
         constraints.gridy = row;
         constraints.anchor = GridBagConstraints.NORTH;
         constraints.insets = new Insets(margins.getTop(), margins.getInternalSpacing(), margins.getBottom(),
-                                        margins.getInternalSpacing());
+                margins.getInternalSpacing());
         add(field.getHelpLabel(), constraints);
     }
 
     /**
-     * Invoked internally to render the validation label for the given FormField, if it has one.
+     * Invoked internally to render the validation label for the given FormField, if
+     * it has one.
      */
     private void renderValidationLabel(FormField field, int row, Margins margins) {
-        // We need to render it unconditionally because it might have a right margin that we need to honor
-        //if (!field.hasValidationLabel()) {
-        //    return;
-        //}
+        // We need to render it unconditionally because it might have a right margin
+        // that we need to honor
+        // if (!field.hasValidationLabel()) {
+        // return;
+        // }
 
         GridBagConstraints constraints = new GridBagConstraints();
         constraints.gridx = VALIDATION_COLUMN;
         constraints.gridy = row;
         constraints.anchor = GridBagConstraints.NORTH;
         constraints.insets = new Insets(margins.getTop(), margins.getInternalSpacing(), margins.getBottom(),
-                                        margins.getRight());
+                margins.getRight());
         add(field.getValidationLabel(), constraints);
     }
 
@@ -388,18 +436,17 @@ public final class FormPanel extends JPanel {
         constraints.fill = GridBagConstraints.BOTH;
         if (alignment.isTopAligned()) {
             constraints.weighty = 0.0; // addFooterMargin will force the form to the top
-        }
-        else if (alignment.isCenteredVertically()) {
+        } else if (alignment.isCenteredVertically()) {
             constraints.weighty = 0.5; // Center the form
-        }
-        else if (alignment.isBottomAligned()) {
+        } else if (alignment.isBottomAligned()) {
             constraints.weighty = 1; // Force the form to the bottom of the panel
         }
         this.add(new JLabel(), constraints);
     }
 
     /**
-     * Adds a left margin to the given grid row to align the form field horizontally on that row.
+     * Adds a left margin to the given grid row to align the form field horizontally
+     * on that row.
      */
     private void addLeftMargin(int row) {
         GridBagConstraints constraints = new GridBagConstraints();
@@ -408,18 +455,17 @@ public final class FormPanel extends JPanel {
         constraints.fill = GridBagConstraints.BOTH;
         if (alignment.isLeftAligned()) {
             constraints.weightx = 0.0; // addRightMargin will force the form to the left
-        }
-        else if (alignment.isCenteredHorizontally()) {
+        } else if (alignment.isCenteredHorizontally()) {
             constraints.weightx = 0.5; // center the form
-        }
-        else if (alignment.isRightAligned()) {
+        } else if (alignment.isRightAligned()) {
             constraints.weightx = 1.0; // Force the form to the right
         }
         add(new JLabel(), constraints);
     }
 
     /**
-     * Adds a right margin to the given grid row to align the form field horizontally on that row.
+     * Adds a right margin to the given grid row to align the form field
+     * horizontally on that row.
      */
     private void addRightMargin(int row) {
         GridBagConstraints constraints = new GridBagConstraints();
@@ -428,11 +474,9 @@ public final class FormPanel extends JPanel {
         constraints.fill = GridBagConstraints.BOTH;
         if (alignment.isLeftAligned()) {
             constraints.weightx = 1.0; // Force the form to the left
-        }
-        else if (alignment.isCenteredHorizontally()) {
+        } else if (alignment.isCenteredHorizontally()) {
             constraints.weightx = 0.5; // center the form
-        }
-        else if (alignment.isRightAligned()) {
+        } else if (alignment.isRightAligned()) {
             constraints.weightx = 0.0; // addLeftMargin will force the form to the right
         }
         add(new JLabel(), constraints);
@@ -448,24 +492,26 @@ public final class FormPanel extends JPanel {
         constraints.fill = GridBagConstraints.BOTH;
         if (alignment.isTopAligned()) {
             constraints.weighty = 1.0; // Force the form to the top
-        }
-        else if (alignment.isCenteredVertically()) {
+        } else if (alignment.isCenteredVertically()) {
             constraints.weighty = 0.5; // Center the form
-        }
-        else if (alignment.isBottomAligned()) {
+        } else if (alignment.isBottomAligned()) {
             constraints.weighty = 0.0; // addHeaderMargin will force the form to the bottom
         }
         this.add(new JLabel(), constraints);
     }
 
     /**
-     * Applies our borderMargin to the FormField at the given fieldIndex based on its
-     * position within our form field list. The first field in the list is the topmost
-     * field, so it will receive an extra top margin, for example. All fields in the list
+     * Applies our borderMargin to the FormField at the given fieldIndex based on
+     * its
+     * position within our form field list. The first field in the list is the
+     * topmost
+     * field, so it will receive an extra top margin, for example. All fields in the
+     * list
      * will receive an extra left and right margin, and the last field in the list
      * will receive an extra bottom margin. The borderMargin value is added to the
      * FormField's existing margins. The FormField's margins are not modified as a
-     * result of this calculation. Instead, a new Margins object will be created and returned.
+     * result of this calculation. Instead, a new Margins object will be created and
+     * returned.
      */
     private Margins calculateFieldMargins(int fieldIndex) {
         FormField field = formFields.get(fieldIndex);


### PR DESCRIPTION
This PR addresses a `TODO` in `FormPanel.java` by removing a hard-coded "magic number" used for the top margin of multi-line fields.

### Changes Made
* Added a private field `multiLineTopMargin` with a default value of `4` (preserving existing behavior).
* Added a public setter method `setMultiLineTopMargin(int margin)` to allow developers to customize this value.
* Updated the `renderFieldLabel` method to use this configurable property instead of the hard-coded value.

### Motivation
The previous implementation had a hard-coded value of `4` with a comment: `// TODO don't hard-code this value`. This change resolves that technical debt and makes the `FormPanel` more flexible for users who need different spacing.