### PR TITLE
Issue #179 - fix minor drag-and-drop bug in ImageListPanel

### DIFF
--- a/src/main/java/ca/corbett/extras/image/ImageListPanel.java
+++ b/src/main/java/ca/corbett/extras/image/ImageListPanel.java
@@ -465,6 +465,7 @@ public class ImageListPanel extends JPanel {
                     }
                     catch (UnsupportedFlavorException | IOException e) {
                         log.warning("ImageListField: drag-and-drop supports images only.");
+                        dtde.dropComplete(false);
                     }
                 }
                 else {

--- a/src/main/resources/swing-extras/releaseNotes.txt
+++ b/src/main/resources/swing-extras/releaseNotes.txt
@@ -2,6 +2,7 @@ swing-extras Release Notes
 Author: Steve Corbett
 
 Version 2.6.0 [TODO date here] - Maintenance release
+  #179 - ImageListPanel: fix minor drag-and-drop bug
   #175 - ExtensionManagerDialog: cache downloaded screenshots
   #174 - Improved logging in UpdateManager
   #173 - Fix minor bug when launching LogConsole from AboutDialog


### PR DESCRIPTION
ImageListPanel had one particular edge case where the `dropComplete` method was not being invoked, potentially leaving the drag-and-drop system in an unspecified state. This PR addresses the problem.