### PR TITLE
Issue #210 - add access to checkbox text in CheckBoxField

### DIFF
--- a/src/main/java/ca/corbett/forms/fields/CheckBoxField.java
+++ b/src/main/java/ca/corbett/forms/fields/CheckBoxField.java
@@ -34,6 +34,21 @@ public final class CheckBoxField extends FormField {
         return !fieldValidators.isEmpty();
     }
 
+    /**
+     * Exposes the text from the underlying JCheckBox.
+     */
+    public String getCheckBoxText() {
+        return ((JCheckBox)fieldComponent).getText();
+    }
+
+    /**
+     * Allows updating the label text in the underlying JCheckBox.
+     */
+    public CheckBoxField setCheckBoxText(String text) {
+        ((JCheckBox)fieldComponent).setText(text);
+        return this;
+    }
+
     public boolean isChecked() {
         return ((JCheckBox)fieldComponent).isSelected();
     }

--- a/src/main/resources/swing-extras/releaseNotes.txt
+++ b/src/main/resources/swing-extras/releaseNotes.txt
@@ -2,6 +2,7 @@ swing-extras Release Notes
 Author: Steve Corbett
 
 Version 2.6.0 [2025-12-31] - Maintenance release
+  #210 - Allow CheckBoxField to get/set checkbox text
   #208 - New FieldValidator: ListEmptySelectionValidator
   #204 - PopupTextDialog: hide Cancel button in read-only mode
   #203 - New FormField: ButtonField / ButtonProperty

--- a/src/test/java/ca/corbett/forms/fields/CheckBoxFieldTest.java
+++ b/src/test/java/ca/corbett/forms/fields/CheckBoxFieldTest.java
@@ -76,6 +76,14 @@ class CheckBoxFieldTest extends FormFieldBaseTests {
     }
 
     @Test
+    public void setCheckBoxText() {
+        CheckBoxField actualField = (CheckBoxField)actual;
+        assertEquals("test", actualField.getCheckBoxText());
+        actualField.setCheckBoxText("new text");
+        assertEquals("new text", actualField.getCheckBoxText());
+    }
+
+    @Test
     public void validate_invalidScenario() {
         CheckBoxField actualField = (CheckBoxField)actual;
         actual.addFieldValidator(new TestValidator());


### PR DESCRIPTION
This PR addresses an oversight in CheckBoxField, which was missing a getter and setter for updating the checkbox label text after initial construction. Callers could cast the result of getFieldComponent() to a JCheckBox and access it that way, but as a convenience, it is preferable to have wrapper methods in CheckBoxField.