### PR TITLE
Issue #242 added VersionStringComparator convenience methods

### DIFF
--- a/src/main/java/ca/corbett/updates/VersionStringComparator.java
+++ b/src/main/java/ca/corbett/updates/VersionStringComparator.java
@@ -61,6 +61,30 @@ public class VersionStringComparator implements Comparator<String> {
 
     /**
      * Convenience method to quickly compare a candidate version and report if it is
+     * at least (equal to or newer than) the given target version.
+     */
+    public static boolean isAtLeast(String candidateVersion, String targetVersion) {
+        return comparator.compare(candidateVersion, targetVersion) >= 0;
+    }
+
+    /**
+     * Convenience method to quickly compare a candidate version and report if it is
+     * at most (equal to or older than) the given target version.
+     */
+    public static boolean isAtMost(String candidateVersion, String targetVersion) {
+        return comparator.compare(candidateVersion, targetVersion) <= 0;
+    }
+
+    /**
+     * Convenience method to quickly compare a candidate version and report if it is
+     * exactly equal to the given target version.
+     */
+    public static boolean isExactly(String candidateVersion, String targetVersion) {
+        return comparator.compare(candidateVersion, targetVersion) == 0;
+    }
+
+    /**
+     * Convenience method to quickly compare a candidate version and report if it is
      * newer (higher version number) than the given target version.
      */
     public static boolean isNewerThan(String candidateVersion, String targetVersion) {

--- a/src/main/resources/swing-extras/releaseNotes.txt
+++ b/src/main/resources/swing-extras/releaseNotes.txt
@@ -5,6 +5,7 @@ Version 2.7.0 [TODO release date here] - Maintenance release
   #257 - new FileSystemUtil method: getUniqueDestinationFile()
   #256 - DirTree: remove Linux-specific logic
   #247 - DirTree: add selectionWillChange event with veto option
+  #242 - Added more VersionStringComparator convenience methods
   #239 - PropertiesManager: add option to set border margin
   #232 - DirTree: add option to show hidden files
   #230 - DirTree: mark factory methods as deprecated

--- a/src/test/java/ca/corbett/updates/VersionStringComparatorTest.java
+++ b/src/test/java/ca/corbett/updates/VersionStringComparatorTest.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class VersionStringComparatorTest {
@@ -47,16 +48,22 @@ class VersionStringComparatorTest {
 
     @Test
     public void isNewerThan() {
+        // Happy path
         assertTrue(VersionStringComparator.isNewerThan("1.1", "1.0"));
         assertTrue(VersionStringComparator.isNewerThan("1.1", "1"));
         assertTrue(VersionStringComparator.isNewerThan("1.1", "1.0.1"));
         assertTrue(VersionStringComparator.isNewerThan("1", "0"));
         assertTrue(VersionStringComparator.isNewerThan("1", "0.9"));
         assertTrue(VersionStringComparator.isNewerThan("11", "1.111111"));
+
+        // Unhappy path
+        assertFalse(VersionStringComparator.isNewerThan("1.0", "1.0"));
+        assertFalse(VersionStringComparator.isNewerThan("1.0", "1.1"));
     }
 
     @Test
     public void isOlderThan() {
+        // Happy path
         assertTrue(VersionStringComparator.isOlderThan("1.0", "2.0"));
         assertTrue(VersionStringComparator.isOlderThan("1.0", "1.1"));
         assertTrue(VersionStringComparator.isOlderThan("1.0", "11"));
@@ -64,5 +71,47 @@ class VersionStringComparatorTest {
         assertTrue(VersionStringComparator.isOlderThan("1.0", "2"));
         assertTrue(VersionStringComparator.isOlderThan("1.0", "2.0.0.0.0"));
         assertTrue(VersionStringComparator.isOlderThan("1.0", "10"));
+
+        // Unhappy path
+        assertFalse(VersionStringComparator.isOlderThan("1.0", "1.0"));
+        assertFalse(VersionStringComparator.isOlderThan("2.0", "1.0"));
+    }
+
+    @Test
+    public void isAtLeast() {
+        // Happy path
+        assertTrue(VersionStringComparator.isAtLeast("1.1", "1.0"));
+        assertTrue(VersionStringComparator.isAtLeast("1.0", "1.0"));
+        assertTrue(VersionStringComparator.isAtLeast("1.0", "0.9"));
+        assertTrue(VersionStringComparator.isAtLeast("2.0", "1.9.9"));
+
+        // Unhappy path
+        assertFalse(VersionStringComparator.isAtLeast("1.0", "1.1"));
+        assertFalse(VersionStringComparator.isAtLeast("1.0", "10.10"));
+    }
+
+    @Test
+    public void isAtMost() {
+        // Happy path
+        assertTrue(VersionStringComparator.isAtMost("1.0", "1.1"));
+        assertTrue(VersionStringComparator.isAtMost("1.0", "1.0"));
+        assertTrue(VersionStringComparator.isAtMost("0.9", "1.0"));
+        assertTrue(VersionStringComparator.isAtMost("1.9.9", "2.0"));
+
+        // Unhappy path
+        assertFalse(VersionStringComparator.isAtMost("1.1", "1.0"));
+        assertFalse(VersionStringComparator.isAtMost("10.10", "1.0"));
+    }
+
+    @Test
+    public void isExactly() {
+        // Happy path
+        assertTrue(VersionStringComparator.isExactly("1.0", "1.0"));
+        assertTrue(VersionStringComparator.isExactly("1.0.0.0.0.0", "1.0"));
+
+        // Unhappy path
+        assertFalse(VersionStringComparator.isExactly("1.0", "1.1"));
+        assertFalse(VersionStringComparator.isExactly("1.0", "0.9"));
+        assertFalse(VersionStringComparator.isExactly("2.0", "1.9.9"));
     }
 }


### PR DESCRIPTION
This PR addresses issue #242 by adding some more static convenience methods to the `VersionStringComparator` class. Also added unit tests to prove out the expected behavior.