### PR TITLE
Issue #275 - attempt to fix intermittent test failure

### DIFF
--- a/src/main/resources/swing-extras/releaseNotes.txt
+++ b/src/main/resources/swing-extras/releaseNotes.txt
@@ -3,6 +3,7 @@ Author: Steve Corbett
 
 Version 2.7.0 [TODO release date here] - Maintenance release
   #276 - MultiProgressDialog: make progress label configurable
+  #275 - Fix intermittent bug in SingleInstanceManager test
   #264 - ListSubsetField: fire value changed events when items move
   #257 - new FileSystemUtil method: getUniqueDestinationFile()
   #256 - DirTree: remove Linux-specific logic


### PR DESCRIPTION
This PR introduces a test change that attempts to fix the intermittent test failure described in issue #275 - the exact cause of the failure is unknown. The plan is to run for a while with this change in place and see if the failure remains. A new ticket will be opened if so.