### PR TITLE
Issue #297 - minor tweak to ListField/ListProperty

### DIFF
--- a/src/main/java/ca/corbett/extras/properties/ListProperty.java
+++ b/src/main/java/ca/corbett/extras/properties/ListProperty.java
@@ -234,6 +234,21 @@ public class ListProperty<T> extends AbstractProperty {
     }
 
     /**
+     * A convenience method to set button alignment, horizontal gap, and vertical gap all at once.
+     *
+     * @param buttonAlignment One of the FlowLayout alignment options: LEFT, CENTER, RIGHT, LEADING, or TRAILING.
+     * @param buttonHgap      The horizontal gap between buttons, in pixels.
+     * @param buttonVgap      The vertical gap between the buttons and the list, in pixels.
+     * @return This ListProperty, for method chaining.
+     */
+    public ListProperty setButtonLayout(int buttonAlignment, int buttonHgap, int buttonVgap) {
+        this.buttonAlignment = buttonAlignment;
+        this.buttonHgap = buttonHgap;
+        this.buttonVgap = buttonVgap;
+        return this;
+    }
+
+    /**
      * If the ListField generated from this property is to include buttons,
      * this gets the preferred dimensions of those buttons (requires a FormFieldGenerationListener to add buttons).
      *

--- a/src/main/java/ca/corbett/forms/fields/ListField.java
+++ b/src/main/java/ca/corbett/forms/fields/ListField.java
@@ -475,6 +475,21 @@ public class ListField<T> extends FormField {
     }
 
     /**
+     * A convenience method to set alignment, hgap, and vgap all at once.
+     *
+     * @param alignment One of the FlowLayout alignment options: LEFT, CENTER, RIGHT, LEADING, or TRAILING
+     * @param hgap      The horizontal gap between buttons, in pixels
+     * @param vgap      The vertical gap between the buttons and the list, in pixels
+     * @return this ListField instance, for call chaining
+     */
+    public ListField<T> setButtonLayout(int alignment, int hgap, int vgap) {
+        layout.setAlignment(alignment);
+        layout.setHgap(hgap);
+        layout.setVgap(vgap);
+        return this;
+    }
+
+    /**
      * Invoked internally to build our wrapper panel, our button panel, and our scroll pane.
      */
     private JComponent buildComponent() {

--- a/src/main/resources/swing-extras/releaseNotes.txt
+++ b/src/main/resources/swing-extras/releaseNotes.txt
@@ -2,6 +2,7 @@ swing-extras Release Notes
 Author: Steve Corbett
 
 Version 2.7.0 [TODO release date here] - Maintenance release
+  #297 - ListField: minor API tweak
   #293 - KeyStrokeManager: minor API improvements
   #289 - DirTree: add listener notification for hidden file toggle
   #287 - MultiProgressDialog: make label truncation configurable

--- a/src/test/java/ca/corbett/extras/properties/ListPropertyTest.java
+++ b/src/test/java/ca/corbett/extras/properties/ListPropertyTest.java
@@ -80,4 +80,21 @@ class ListPropertyTest extends AbstractPropertyBaseTests {
         assertEquals(200, preferredSize.width);
         assertEquals(150, preferredSize.height);
     }
+
+    @Test
+    public void formFieldGenerationListener_withConvenienceMethodForButtonLayout_shouldSetButtonProperties() {
+        // GIVEN a test prop with some optional button properties set via the convenience method:
+        ListProperty<String> testProp = new ListProperty<>("test", "test");
+        testProp.setButtonLayout(FlowLayout.CENTER, 5, 6);
+
+        // WHEN we generate a form field:
+        FormField formField = testProp.generateFormField();
+
+        // THEN we should see our button properties were applied to the form field:
+        assertInstanceOf(ListField.class, formField);
+        ListField<?> listField = (ListField<?>)formField;
+        assertEquals(FlowLayout.CENTER, listField.getButtonAlignment());
+        assertEquals(5, listField.getButtonHgap());
+        assertEquals(6, listField.getButtonVgap());
+    }
 }


### PR DESCRIPTION
This PR addresses issue #297 by adding a convenience method to the `ListField` and `ListProperty` classes to save a small amount of code when setting button layout options. The new convenience method is in addition to, and does not replace, the existing setter methods, so there is no breakage of existing code.