### PR TITLE
Javadoc pass and misc cleanup

### DIFF
--- a/src/main/java/ca/corbett/extras/demo/panels/IntroPanel.java
+++ b/src/main/java/ca/corbett/extras/demo/panels/IntroPanel.java
@@ -80,7 +80,7 @@ public class IntroPanel extends PanelBuilder {
         addHyperlinkIfUrlIsValid(labelField, javadocUrl);
         introPanel.add(labelField);
 
-        labelField = new LabelField("Copyright:", "2012-2025 Steve Corbett");
+        labelField = new LabelField(Version.COPYRIGHT);
         labelField.getFieldLabel().setFont(labelFont);
         labelField.setFont(labelFont);
         labelField.getMargins().setLeft(48); // indent

--- a/src/main/java/ca/corbett/extras/io/FileSystemUtil.java
+++ b/src/main/java/ca/corbett/extras/io/FileSystemUtil.java
@@ -19,8 +19,9 @@ import java.util.jar.JarFile;
 import java.util.regex.Pattern;
 
 /**
- * Provides a way to scan, organize, and search through a given file system, looking for
- * specific types of files recursively.
+ * Provides a number of handy static utility methods for working with files and directories.
+ * Searching for files by extension, reading and writing text files, sanitizing filenames,
+ * and more.
  *
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
  * @since 2012-07-28 (originally written for ICE, later generalized for ca.corbett.util)

--- a/src/main/java/ca/corbett/extras/io/HyperlinkUtil.java
+++ b/src/main/java/ca/corbett/extras/io/HyperlinkUtil.java
@@ -16,6 +16,11 @@ import java.util.logging.Logger;
 
 /**
  * Utility class for hyperlink launching in JREs that support it.
+ * Use isBrowsingSupported() to check if the current JRE allows
+ * launching hyperlinks. Use the openHyperlink(...) methods to
+ * easily launch a given hyperlink in the default browser, or
+ * use the many BrowseAction.of() overloads to create an Action
+ * that can be used with buttons, menu items, etc.
  *
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
  * @since swing-extras 2.6

--- a/src/main/java/ca/corbett/extras/io/KeyStrokeManager.java
+++ b/src/main/java/ca/corbett/extras/io/KeyStrokeManager.java
@@ -22,6 +22,34 @@ import java.util.logging.Logger;
  * associated actions will be triggered when the shortcut is pressed.
  * The same Action can be registered multiple times for different shortcuts,
  * in case you want to allow multiple ways of launching the same action.
+ * <H2>Usage Example:</H2>
+ * <pre>
+ *     // Create a KeyStrokeManager for your main window:
+ *     KeyStrokeManager ksm = new KeyStrokeManager(mainWindow);
+ *
+ *     // Add some basic shortcuts:
+ *     ksm.registerHandler("ctrl+O", openFileAction);
+ *     ksm.registerHandler("ctrl+S", saveFileAction);
+ *     ksm.registerHandler("ctrl+A", aboutAction);
+ *
+ *     // That's literally all there is to it!
+ *     // As long as your main window is active,
+ *     // those shortcuts will trigger the associated actions.
+ *
+ *     // You can temporarily disable the manager if needed:
+ *     ksm.setEnabled(false); // disables shortcut processing
+ *     ksm.setEnabled(true);  // re-enables shortcut processing
+ *
+ *     // And you can reassign shortcuts as needed:
+ *     ksm.reassignHandler(saveFileAction, "ctrl+shift+S");
+ * </pre>
+ * <p>
+ *     You should also look at the KeyStrokeProperty and KeyStrokeField
+ *     classes to allow easy user customization of your shortcuts!
+ *     With KeyStrokeProperty, you can easily add these to your
+ *     application settings, where they will be automatically persisted
+ *     between application sessions.
+ * </p>
  *
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
  * @since swing-extras 2.7
@@ -151,7 +179,7 @@ public class KeyStrokeManager {
      * @return A List of Actions assigned to the KeyStroke. Empty if none found.
      * @throws IllegalArgumentException if the given keyStroke string is invalid
      */
-    public List<Action> getActionsForKeyStroke(String keyStroke) throws IllegalArgumentException {
+    public List<Action> getActionsForKeyStroke(String keyStroke) {
         if (!isKeyStrokeValid(keyStroke)) {
             throw new IllegalArgumentException("getActionsForKeyStroke: invalid keyStroke string: " + keyStroke);
         }
@@ -193,7 +221,7 @@ public class KeyStrokeManager {
     /**
      * Shorthand for !hasHandlers(keyStroke)
      */
-    public boolean isAvailable(String keyStroke) throws IllegalArgumentException {
+    public boolean isAvailable(String keyStroke) {
         if (!isKeyStrokeValid(keyStroke)) {
             throw new IllegalArgumentException("isAvailable: invalid keyStroke string: " + keyStroke);
         }
@@ -217,7 +245,7 @@ public class KeyStrokeManager {
      * @return true if at least one action is registered for the KeyStroke, false otherwise
      * @throws IllegalArgumentException If the given keyStroke string is invalid
      */
-    public boolean hasHandlers(String keyStroke) throws IllegalArgumentException {
+    public boolean hasHandlers(String keyStroke) {
         if (!isKeyStrokeValid(keyStroke)) {
             throw new IllegalArgumentException("hasHandlers: invalid keyStroke string: " + keyStroke);
         }
@@ -239,7 +267,7 @@ public class KeyStrokeManager {
      * @return this manager, for fluent-style method chaining
      * @throws IllegalArgumentException if the given shortcut string is invalid
      */
-    public KeyStrokeManager registerHandler(String keyStroke, Action action) throws IllegalArgumentException {
+    public KeyStrokeManager registerHandler(String keyStroke, Action action) {
         if (!isKeyStrokeValid(keyStroke)) {
             throw new IllegalArgumentException("registerHandler: invalid keyStroke string: " + keyStroke);
         }
@@ -313,7 +341,7 @@ public class KeyStrokeManager {
      * @return this manager, for fluent-style method chaining
      * @throws IllegalArgumentException if the given newShortcut string is invalid
      */
-    public KeyStrokeManager reassignHandler(Action action, String newKeyStroke) throws IllegalArgumentException {
+    public KeyStrokeManager reassignHandler(Action action, String newKeyStroke) {
         // We should validate the keyStroke first, so we don't unregister the action if the new shortcut is invalid:
         KeyStroke ks = parseKeyStroke(newKeyStroke);
         if (ks == null) {

--- a/src/main/java/ca/corbett/extras/io/package-info.java
+++ b/src/main/java/ca/corbett/extras/io/package-info.java
@@ -1,4 +1,11 @@
 /**
- * Contains utility classes for searching for files and directories.
+ * Contains utility classes for dealing with input and output operations.
+ * The major classes here are:
+ * <ul>
+ *     <li><b>FileSystemUtil</b> - Many handy methods for working with files and directories.</li>
+ *     <li><b>DownloadManager</b> - Easily download files from the internet with progress monitoring.</li>
+ *     <li><b>HyperlinkUtil</b> - Easily open hyperlinks in the default browser.</li>
+ *     <li><b>KeyStrokeManager</b> - Easily add keyboard shortcuts to any window.</li>
+ * </ul>
  */
 package ca.corbett.extras.io;


### PR DESCRIPTION
This PR addresses some minor cleanup items:

- Removes outdated hardcoded year in the demo application's Intro panel. Use constants from the `Version` class instead.
- A Javadoc pass in the `ca.corbett.extras.io` package found a number of areas where the documentation required updates.
- Removed some unnecessary `throws` declarations for unchecked exceptions in KeyStrokeManager

