### PR TITLE
Issue #315 - fix minor bug in KeyStrokeManager.clear()

### DIFF
--- a/src/main/java/ca/corbett/extras/io/KeyStrokeManager.java
+++ b/src/main/java/ca/corbett/extras/io/KeyStrokeManager.java
@@ -188,8 +188,14 @@ public class KeyStrokeManager {
 
     /**
      * Removes all registered keyboard shortcuts and their associated actions.
+     * This will also clear the accelerator keys from all associated Actions.
      */
     public KeyStrokeManager clear() {
+        for (List<Action> actions : keyMap.values()) {
+            for (Action action : actions) {
+                action.putValue(Action.ACCELERATOR_KEY, null);
+            }
+        }
         keyMap.clear();
         return this;
     }

--- a/src/main/resources/swing-extras/releaseNotes.txt
+++ b/src/main/resources/swing-extras/releaseNotes.txt
@@ -2,6 +2,7 @@ swing-extras Release Notes
 Author: Steve Corbett
 
 Version 2.7.0 [TODO release date here] - Maintenance release
+  #315 - Bug: KeyStrokeManager.clear() was not removing accelerators
   #308 - Bug: ImageTextUtil.drawText() now uses adjusted line length
   #307 - Bug: ImagePanel was doubling mouse events for animated GIFs
   #305 - ImagePanel: add dispose() method to prevent memory leaks

--- a/src/test/java/ca/corbett/extras/io/KeyStrokeManagerTest.java
+++ b/src/test/java/ca/corbett/extras/io/KeyStrokeManagerTest.java
@@ -378,6 +378,25 @@ class KeyStrokeManagerTest {
     }
 
     @Test
+    public void clear_withRegisteredAction_shouldClearActionAccelerator() throws Exception {
+        // GIVEN a registered action:
+        Action action = new AbstractAction("ClearAcceleratorAction") {
+            @Override
+            public void actionPerformed(java.awt.event.ActionEvent e) {
+                // no-op
+            }
+        };
+        keyManager.registerHandler("alt+del", action);
+        assertNotNull(action.getValue(Action.ACCELERATOR_KEY), "Action should have received an accelerator.");
+
+        // WHEN we clear the key manager:
+        keyManager.clear();
+
+        // THEN the action should no longer have an accelerator:
+        assertNull(action.getValue(Action.ACCELERATOR_KEY), "Action accelerator should be cleared after clear()");
+    }
+
+    @Test
     public void dispose_withRegisteredHandlers_shouldClearAll() throws Exception {
         Action action = new AbstractAction("DisposableAction") {
             @Override


### PR DESCRIPTION
This PR addresses issue #315 by fixing a minor bug in `KeyStrokeManager.clear()` where registered actions were not being properly cleared of their ACCELERATOR_KEY value.

Fixed the bug and added a unit test to prove the expected behavior.