### PR TITLE
Fix: help label should not be disabled when FormField is disabled

### DIFF
--- a/src/main/java/ca/corbett/forms/fields/FormField.java
+++ b/src/main/java/ca/corbett/forms/fields/FormField.java
@@ -278,6 +278,12 @@ public abstract class FormField {
 
     /**
      * Enables or disables all components in this field.
+     * <p>
+     * <b>Note:</b> The help label is intentionally not disabled when the field is disabled.
+     * This is because the help label should always be visible and accessible to the user,
+     * even when the field itself is disabled. Descendant classes can override
+     * {@code setEnabled()} to implement their own handling if needed.
+     * </p>
      *
      * @param enabled whether to enable or disable the components.
      */
@@ -288,7 +294,6 @@ public abstract class FormField {
             fieldComponent.setEnabled(enabled);
         }
         validationLabel.setEnabled(enabled);
-        helpLabel.setEnabled(enabled);
         return this;
     }
 

--- a/src/test/java/ca/corbett/forms/fields/FormFieldBaseTests.java
+++ b/src/test/java/ca/corbett/forms/fields/FormFieldBaseTests.java
@@ -35,9 +35,6 @@ public abstract class FormFieldBaseTests {
         if (actual.hasFieldLabel()) {
             assertTrue(actual.getFieldLabel().isEnabled());
         }
-        if (actual.hasHelpLabel()) {
-            assertTrue(actual.getHelpLabel().isEnabled());
-        }
         if (actual.hasValidationLabel()) {
             assertTrue(actual.getValidationLabel().isEnabled());
         }
@@ -47,9 +44,6 @@ public abstract class FormFieldBaseTests {
         assertFalse(actual.getFieldComponent().isEnabled());
         if (actual.hasFieldLabel()) {
             assertFalse(actual.getFieldLabel().isEnabled());
-        }
-        if (actual.hasHelpLabel()) {
-            assertFalse(actual.getHelpLabel().isEnabled());
         }
         if (actual.hasValidationLabel()) {
             assertFalse(actual.getValidationLabel().isEnabled());
@@ -61,12 +55,27 @@ public abstract class FormFieldBaseTests {
         if (actual.hasFieldLabel()) {
             assertTrue(actual.getFieldLabel().isEnabled());
         }
-        if (actual.hasHelpLabel()) {
-            assertTrue(actual.getHelpLabel().isEnabled());
-        }
         if (actual.hasValidationLabel()) {
             assertTrue(actual.getValidationLabel().isEnabled());
         }
+    }
+
+    @Test
+    public void testSetEnabled_helpLabelShouldNotBeDisabled() {
+        // Help label should always remain enabled, even when the field is disabled.
+        // This ensures that users can still access help text for disabled fields.
+        // See: https://github.com/scorbo2/swing-extras/issues/324
+        actual.setHelpText("Some help text");
+        assertTrue(actual.hasHelpLabel());
+        assertTrue(actual.getHelpLabel().isEnabled());
+
+        actual.setEnabled(false);
+        assertFalse(actual.isEnabled());
+        assertTrue(actual.getHelpLabel().isEnabled(), "Help label should remain enabled when field is disabled");
+
+        actual.setEnabled(true);
+        assertTrue(actual.isEnabled());
+        assertTrue(actual.getHelpLabel().isEnabled());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Fixed issue where help label was getting disabled when FormField is disabled
- Help label now stays enabled so users can still access help text for disabled fields
- Added dedicated test to verify help label behavior

Fixes #324