### PR TITLE
fix: treat null validator result as valid

### DIFF
--- a/src/main/java/ca/corbett/forms/fields/FormField.java
+++ b/src/main/java/ca/corbett/forms/fields/FormField.java
@@ -433,6 +433,9 @@ public abstract class FormField {
             //noinspection unchecked
             FieldValidator<FormField> theValidator = (FieldValidator<FormField>)validator;
             ValidationResult validationResult = theValidator.validate(this);
+            if (validationResult == null) {
+                validationResult = ValidationResult.valid();
+            }
             isValid = isValid && validationResult.isValid();
             if (!validationResult.isValid()) {
                 validationMessages.add(validationResult.getMessage());

--- a/src/main/java/ca/corbett/forms/validators/FieldValidator.java
+++ b/src/main/java/ca/corbett/forms/validators/FieldValidator.java
@@ -28,6 +28,7 @@ public interface FieldValidator<T extends FormField> {
      *
      * @param fieldToValidate The FormField to be validated.
      * @return A ValidationResult which describes whether the current value in our field is valid.
+     * Returning {@code null} is discouraged but treated the same as {@link ValidationResult#valid()}.
      */
     ValidationResult validate(T fieldToValidate);
 }

--- a/src/test/java/ca/corbett/forms/fields/FormFieldBaseTests.java
+++ b/src/test/java/ca/corbett/forms/fields/FormFieldBaseTests.java
@@ -172,6 +172,13 @@ public abstract class FormFieldBaseTests {
     }
 
     @Test
+    public void validate_withNullReturningValidator_shouldTreatAsValid() {
+        actual.addFieldValidator(field -> null);
+        assertTrue(actual.isValid());
+        assertNull(actual.getValidationLabel().getToolTipText());
+    }
+
+    @Test
     public void testExtraAttributes() {
         assertNull(actual.getExtraAttribute("test"));
         actual.setExtraAttribute("test", "value");


### PR DESCRIPTION
## Summary
- guard FormField.validate() against null ValidationResult by treating null as valid
- document in FieldValidator Javadoc that null is treated as valid but discouraged
- add regression test covering a validator that returns null

## Rationale
Issue #354 reports a NullPointerException when a FieldValidator mistakenly returns null. The fix makes validation resilient to that misuse and clarifies expected behavior.

## Changes
- FormField.validate now defaults null results to ValidationResult.valid()
- FieldValidator JavaDoc notes null is accepted but not recommended
- FormFieldBaseTests includes a null-returning validator test

Fixes #354