### PR TITLE
Issue #365 - fix annoying unit test glitch

### DIFF
--- a/src/test/java/ca/corbett/extras/io/HyperlinkUtilTest.java
+++ b/src/test/java/ca/corbett/extras/io/HyperlinkUtilTest.java
@@ -39,7 +39,13 @@ class HyperlinkUtilTest {
     void setUp() {
         // Make a note of whatever is currently in the system clipboard,
         // because some of these tests will copy stuff to it:
-        clipboardContents = Toolkit.getDefaultToolkit().getSystemClipboard().getContents(null);
+        try {
+            clipboardContents = Toolkit.getDefaultToolkit().getSystemClipboard().getContents(null);
+        }
+        catch (IllegalStateException ignored) {
+            // Clipboard is currently unavailable; treat as no prior contents.
+            clipboardContents = null;
+        }
 
         mockBrowser = Mockito.mock(HyperlinkUtil.DesktopBrowser.class);
         HyperlinkUtil.setDesktopBrowser(mockBrowser);


### PR DESCRIPTION
This PR addresses issue #365 by fixing a small but annoying unit test bug involving the system clipboard.

Because this change only affects the unit tests and no actual code, it is deliberately not added to releaseNotes.txt.