### PR TITLE
Issue #381 - tweaking the Margins class

### DIFF
--- a/src/main/java/ca/corbett/forms/Margins.java
+++ b/src/main/java/ca/corbett/forms/Margins.java
@@ -3,6 +3,7 @@ package ca.corbett.forms;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Logger;
 
 /**
  * Can be used to specify margins and padding around and inside a FormField,
@@ -39,6 +40,8 @@ import java.util.concurrent.CopyOnWriteArrayList;
  * @since swing-extras 2.4
  */
 public class Margins {
+
+    private static final Logger log = Logger.getLogger(Margins.class.getName());
 
     /**
      * A very simple interface that can be used to listen for changes to a Margins instance.
@@ -96,16 +99,14 @@ public class Margins {
      * this call does nothing.
      */
     public Margins copy(Margins other) {
-        if (other == null) {
-            throw new IllegalArgumentException("Margins to copy may not be null.");
+        if (other != null) {
+            this.left = validateInput(other.left);
+            this.top = validateInput(other.top);
+            this.right = validateInput(other.right);
+            this.bottom = validateInput(other.bottom);
+            this.internalSpacing = validateInput(other.internalSpacing);
+            fireChangeEvent(); // Just fire one event for this
         }
-
-        this.left = validateInput(other.left);
-        this.top = validateInput(other.top);
-        this.right = validateInput(other.right);
-        this.bottom = validateInput(other.bottom);
-        this.internalSpacing = validateInput(other.internalSpacing);
-        fireChangeEvent(); // Just fire one event for this
         return this;
     }
 
@@ -174,7 +175,8 @@ public class Margins {
 
     private int validateInput(int input) {
         if (input < 0) {
-            throw new IllegalArgumentException("Margin values cannot be negative. Invalid value: " + input);
+            log.warning("Margins: ignoring negative margin: " + input);
+            return 0; // legacy behavior expected by callers
         }
         return input;
     }
@@ -185,6 +187,9 @@ public class Margins {
      * all registered listeners will be notified via their marginsChanged() method.
      */
     public Margins addListener(Listener listener) {
+        if (listener == null) {
+            throw new IllegalArgumentException("listener cannot be null");
+        }
         listeners.add(listener);
         return this;
     }
@@ -194,6 +199,9 @@ public class Margins {
      * that was previously added via addListener().
      */
     public Margins removeListener(Listener listener) {
+        if (listener == null) {
+            throw new IllegalArgumentException("listener cannot be null");
+        }
         listeners.remove(listener);
         return this;
     }

--- a/src/test/java/ca/corbett/forms/MarginsTest.java
+++ b/src/test/java/ca/corbett/forms/MarginsTest.java
@@ -2,9 +2,10 @@ package ca.corbett.forms;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 
 class MarginsTest {
 
@@ -124,19 +125,22 @@ class MarginsTest {
 
     @Test
     public void testNegativeValues_shouldReject() {
-        try {
-            new Margins(-1);
-            new Margins(-1, -1, -1, -1, -1);
-            Margins actual3 = new Margins();
-            actual3.setLeft(-1);
-            actual3.setRight(-1);
-            actual3.setTop(-1);
-            actual3.setBottom(-1);
-            actual3.setInternalSpacing(-1);
-            fail("At least one of the above should have thrown an IllegalArgumentException for negative input");
-        }
-        catch (IllegalArgumentException ignored) {
-            // Expected exception
+        Margins actual1 = new Margins(-1);
+        Margins actual2 = new Margins(-1, -1, -1, -1, -1);
+        Margins actual3 = new Margins();
+        actual3.setLeft(-1);
+        actual3.setRight(-1);
+        actual3.setTop(-1);
+        actual3.setBottom(-1);
+        actual3.setInternalSpacing(-1);
+
+        List<Margins> margins = List.of(actual1, actual2, actual3);
+        for (Margins margin : margins) {
+            assertEquals(0, margin.getInternalSpacing());
+            assertEquals(0, margin.getLeft());
+            assertEquals(0, margin.getRight());
+            assertEquals(0, margin.getTop());
+            assertEquals(0, margin.getBottom());
         }
     }
 


### PR DESCRIPTION
This PR addresses issue #381 by making some small changes to the `Margins` class:

- modified javadocs to downplay the linkage to swing-forms. This class is generic enough to be used elsewhere. A future release of swing-extras may move it out of the forms package to a more general utility location.
- added a very simple listener interface so callers can be notified of changes.
- upgraded error handling to throw IllegalArgumentException instead of just logging and then ignoring bad input.
- Added unit tests for new listener functionality; updated existing test for bad input.

