### PR TITLE
Issue #398 - ActionPanel was not scrollable on new PropertiesDialog

### DIFF
--- a/src/main/java/ca/corbett/extras/properties/dialog/ActionPanelPropertiesDialog.java
+++ b/src/main/java/ca/corbett/extras/properties/dialog/ActionPanelPropertiesDialog.java
@@ -147,7 +147,7 @@ public class ActionPanelPropertiesDialog extends PropertiesDialog {
             actionPanel.setHighlightedAction(firstCardId);
         }
 
-        add(actionPanel, BorderLayout.WEST);
+        add(ScrollUtil.buildScrollPane(actionPanel), BorderLayout.WEST);
         add(cardPanel, BorderLayout.CENTER);
     }
 

--- a/src/main/resources/swing-extras/releaseNotes.txt
+++ b/src/main/resources/swing-extras/releaseNotes.txt
@@ -2,6 +2,7 @@ swing-extras Release Notes
 Author: Steve Corbett
 
 Version 2.8.0 [TODO release date]
+  #398 - PropertiesDialog: ensure ActionPanel is scrollable
   #393 - Fix bug in ToggleableTabbedPane with L&F changes
   #386 - GradientUtil: add circular gradient option
   #382 - New FormField: MarginsField / MarginsProperty


### PR DESCRIPTION
This PR addresses issue #398 by fixing a simple bug in the new ActionPanelPropertiesDialog, where the ActionPanel was not being placed into a JScrollPane. For large properties lists, this would result in display problems, with part of the ActionPanel not being visible.