### PR TITLE
Issue #399 - better PropertiesDialog customization for AppProperties subclasses

### DIFF
--- a/src/main/java/ca/corbett/extensions/AppProperties.java
+++ b/src/main/java/ca/corbett/extensions/AppProperties.java
@@ -9,7 +9,6 @@ import ca.corbett.forms.Alignment;
 import ca.corbett.updates.UpdateManager;
 
 import javax.swing.JOptionPane;
-import java.awt.Dimension;
 import java.awt.Frame;
 import java.awt.Window;
 import java.io.File;
@@ -46,11 +45,22 @@ import java.util.logging.Logger;
  * up in the PropertiesDialog until the extension is enabled again.
  * </p>
  * <p>
- * Refer to the <a href="http://www.corbett.ca/swing-extras-book/">swing-extras documentation</a> for more information.
+ * <b>Customizing the generated PropertiesDialog</b><br>
+ * When you invoke showPropertiesDialog(), this class will generate a default PropertiesDialog
+ * for you, and then show it to the user. But what if you want to customize
+ * the generated dialog before it's shown to the user? For example, you might want to make
+ * it larger than the default size, or add extra padding around the FormPanels, or customize
+ * the ActionPanel if it's an ActionPanelPropertiesDialog. You can do all of that by
+ * overriding the propertiesDialogCreated() method, which is invoked after the dialog is created but before
+ * it's shown to the user.
+ * </p>
+ * <p>
+ * Refer to the <a href="http://www.corbett.ca/swing-extras-book/">swing-extras documentation</a>
+ * for more information on how AppProperties works, and how applications can take full advantage of its features!
  * </p>
  *
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
- * @since 2024-12-30
+ * @since swing-extras 1.8, 2024-12-30
  */
 public abstract class AppProperties<T extends AppExtension> {
 
@@ -61,15 +71,6 @@ public abstract class AppProperties<T extends AppExtension> {
 
     private final String appName;
     private final File propsFile;
-
-    // Subclasses can change these as they see fit:
-    protected int propertiesDialogInitialWidth = PropertiesDialog.INITIAL_WIDTH;
-    protected int propertiesDialogInitialHeight = PropertiesDialog.INITIAL_HEIGHT;
-    protected int propertiesDialogMinimumWidth = PropertiesDialog.MINIMUM_WIDTH;
-    protected int propertiesDialogMinimumHeight = PropertiesDialog.MINIMUM_HEIGHT;
-
-    // The border margin on generated form panels can also be adjusted by subclasses if desired:
-    protected int propertiesDialogFormPanelBorderMargin = 16;
 
 
     /**
@@ -192,6 +193,10 @@ public abstract class AppProperties<T extends AppExtension> {
     /**
      * Generates and shows a PropertiesDialog to allow the user to view or change any
      * of the current properties. If the user okays the dialog, changes are automatically saved.
+     * <p>
+     *     <b>Note:</b> Descendant classes can customize the PropertiesDialog before
+     *     it is shown to the user! See the propertiesDialogCreated() method for details.
+     * </p>
      *
      * @param owner The owning Frame (so we can make the dialog modal to that Frame).
      * @return true if the user OK'd the dialog and changes were made - reload your UI!
@@ -203,6 +208,10 @@ public abstract class AppProperties<T extends AppExtension> {
     /**
      * Generates and shows a PropertiesDialog to allow the user to view or change any
      * of the current properties. If the user okays the dialog, changes are automatically saved.
+     * <p>
+     *     <b>Note:</b> Descendant classes can customize the PropertiesDialog before
+     *     it is shown to the user! See the propertiesDialogCreated() method for details.
+     * </p>
      *
      * @param owner     The owning Frame (so we can make the dialog modal to that Frame).
      * @param alignment How the FormPanels should align themselves.
@@ -214,17 +223,51 @@ public abstract class AppProperties<T extends AppExtension> {
                                                               appName + " properties",
                                                                      true);
         dialog.setAlignment(alignment);
-        dialog.setBorderMargin(propertiesDialogFormPanelBorderMargin);
-        dialog.setSize(propertiesDialogInitialWidth, propertiesDialogInitialHeight);
-        dialog.setMinimumSize(new Dimension(propertiesDialogMinimumWidth, propertiesDialogMinimumHeight));
-        dialog.setVisible(true);
 
+        // Give subclasses a chance to customize this dialog before we show it:
+        propertiesDialogCreated(dialog);
+
+        // Now we can show it and get the result:
+        dialog.setVisible(true);
         if (dialog.wasOkayed()) {
             propsManager.updateFromDialog(dialog);
             save();
         }
 
         return dialog.wasOkayed();
+    }
+
+    /**
+     * Subclasses can override this method to make adjustments to the PropertiesDialog after it's created,
+     * but before it's shown to the user. For example:
+     * <pre>
+     * &#64;Override
+     * protected void propertiesDialogCreated(PropertiesDialog dialog) {
+     *   dialog.setSize(800, 600); // make larger than default
+     *   dialog.setMinimumSize(new Dimension(600, 400)); // but not smaller than this
+     *   dialog.setBorderMargin(20); // add lots of extra padding around the FormPanels
+     *
+     *   // If we're showing an ActionPanel, we can customize it here:
+     *   if (dialog instanceof ActionPanelPropertiesDialog) {
+     *     ActionPanelPropertiesDialog apd = (ActionPanelPropertiesDialog) dialog;
+     *     apd.getActionPanel().getColorOptions().setFromTheme(ColorTheme.DARK);
+     *   }
+     * }
+     * </pre>
+     * <p>
+     * You can also get access to generated FormField instances using PropertiesDialog.findFormField(),
+     * if you want to make specific adjustments to the starting state of those form fields.
+     * However, it's better practice to add a FormFieldGenerationListener to your AbstractProperty
+     * instances for that purpose.
+     * </p>
+     *
+     * @param dialog The PropertiesDialog that was just created, but has not yet been shown to the user.
+     */
+    protected void propertiesDialogCreated(PropertiesDialog dialog) {
+        // Default implementation does nothing.
+        // This method is purely here for subclass use.
+        // Subclasses are of course free to ignore this method.
+        // In that case, they will receive a fully-defaulted PropertiesDialog.
     }
 
     /**

--- a/src/main/java/ca/corbett/extras/properties/dialog/PropertiesDialog.java
+++ b/src/main/java/ca/corbett/extras/properties/dialog/PropertiesDialog.java
@@ -80,7 +80,9 @@ public abstract class PropertiesDialog extends JDialog {
                                                        String title,
                                                        List<AbstractProperty> properties,
                                                        boolean alwaysShowSubcategoryLabels) {
-        return new TabPanePropertiesDialog(owner, title, properties, alwaysShowSubcategoryLabels);
+        PropertiesDialog dialog = new TabPanePropertiesDialog(owner, title, properties, alwaysShowSubcategoryLabels);
+        dialog.initialize(); // Can't invoke overridable methods in constructor, so this goes here.
+        return dialog;
     }
 
     /**
@@ -112,7 +114,9 @@ public abstract class PropertiesDialog extends JDialog {
                                                            String title,
                                                            List<AbstractProperty> properties,
                                                            boolean addPanelHeaders) {
-        return new ActionPanelPropertiesDialog(owner, title, properties, addPanelHeaders);
+        PropertiesDialog dialog = new ActionPanelPropertiesDialog(owner, title, properties, addPanelHeaders);
+        dialog.initialize(); // Can't invoke overridable methods in constructor, so this goes here.
+        return dialog;
     }
 
     /**
@@ -237,7 +241,6 @@ public abstract class PropertiesDialog extends JDialog {
     @Override
     public void setVisible(boolean visible) {
         if (visible) {
-            initialize();
             setLocationRelativeTo(owner);
         }
         super.setVisible(visible);
@@ -273,10 +276,6 @@ public abstract class PropertiesDialog extends JDialog {
      * @return A FormField instance representing that field, or null if not found.
      */
     public FormField findFormField(String identifier) {
-        // Wonky case: this might actually get invoked before we are setVisible(true),
-        // for example in unit tests. So, just make sure we're initialized first:
-        initialize();
-
         // Find the requested field, if we have it:
         for (FormPanel formPanel : formPanels) {
             if (formPanel != null) {

--- a/src/main/resources/swing-extras/releaseNotes.txt
+++ b/src/main/resources/swing-extras/releaseNotes.txt
@@ -2,6 +2,7 @@ swing-extras Release Notes
 Author: Steve Corbett
 
 Version 2.8.0 [TODO release date]
+  #399 - AppProperties: better subclass access to props dialog
   #398 - PropertiesDialog: ensure ActionPanel is scrollable
   #393 - Fix bug in ToggleableTabbedPane with L&F changes
   #386 - GradientUtil: add circular gradient option


### PR DESCRIPTION
This PR addresses issue #399 by making PropertiesDialog customization easier and more effective for subclasses of AppProperties.

The old approach involved changing protected int class variables:

```
// In subclass:
@Override
public boolean showPropertiesDialog(Frame owner, Alignment alignment) {
  propertiesDialogInitialWidth = customWidth;
  propertiesDialogInitialHeight = customHeight;
  return super.showPropertiesDialog(owner, alignment);
}
```

The new approach gives an explicit method that subclasses can override. This method provides the generated PropertiesDialog, after it has been generated, but before it is shown to the user. Client code can then do whatever customization they need:

```
// In subclass:
@Override
protected void propertiesDialogCreated(PropertiesDialog dialog) {
  dialog.setSize(customWidth, customHeight);
  dialog.setBorderMargin(20); // add lots of extra padding around the FormPanels
}
```

The new approach is more powerful than the old approach. Client code can change not just JDialog properties like width and height, but also apply application-specific changes, for example by using `PropertiesDialog.findFormField()` to look up specific FormFields, or casting the `PropertiesDialog` to a specific implementation class and modifying specific aspects of it. Changing the many options of the generated `ActionPanel` is an excellent use case for this.

This is a breaking change for all client applications that used the old approach, but the new approach is so much better, the breakage is justified. The change will be communicated in the release announcement when 2.8 goes out.