### PR TITLE
Issue #402 - fix unexpected behavior in Properties.getString()

### DIFF
--- a/src/main/java/ca/corbett/extras/properties/KeyStrokeProperty.java
+++ b/src/main/java/ca/corbett/extras/properties/KeyStrokeProperty.java
@@ -199,7 +199,8 @@ public class KeyStrokeProperty extends AbstractProperty {
     public void loadFromProps(Properties props) {
         allowBlank = props.getBoolean(fullyQualifiedName + ".allowBlank", allowBlank);
         String reservedStr = props.getString(fullyQualifiedName + ".reservedKeyStrokes",
-                                             listToString(new ArrayList<>(reservedKeyStrokes)));
+                                             listToString(new ArrayList<>(reservedKeyStrokes)),
+                                             true); // Treat blank values as null to allow overwriting them.
         reservedKeyStrokes.clear();
         reservedKeyStrokes.addAll(stringToList(reservedStr));
         reservedKeyStrokeMsg = props.getString(fullyQualifiedName + ".reservedKeyStrokeMsg", reservedKeyStrokeMsg);

--- a/src/main/java/ca/corbett/extras/properties/Properties.java
+++ b/src/main/java/ca/corbett/extras/properties/Properties.java
@@ -79,13 +79,35 @@ public class Properties {
 
     /**
      * Retrieves the String value of the named property, if any.
+     * If the stored value is explicitly blank, then a blank string is returned.
+     * If you wish to treat blank strings the same as null/missing values,
+     * then invoke getString(name, defaultValue, true) instead of this method.
      *
      * @param name         The property name.
      * @param defaultValue A value to receive if no such named property exists.
      * @return The value of the named property, or defaultValue if no such property exists.
      */
     public String getString(String name, String defaultValue) {
-        return props.getProperty(name, defaultValue);
+        return getString(name, defaultValue, false);
+    }
+
+    /**
+     * Retrieves the String value of the named property, if any.
+     * If defaultIfBlank is true, then explicit blank String values in the saved property
+     * will be handled the same way as if the property had a null/missing value.
+     * That is, the given defaultValue will be returned instead of the blank string.
+     *
+     * @param name           The property name.
+     * @param defaultValue   A value to receive if the value is missing or invalid.
+     * @param defaultIfBlank true to treat blank string values the same as null values.
+     * @return The value of the named property, or defaultValue, based on the stored value, as described above.
+     */
+    public String getString(String name, String defaultValue, boolean defaultIfBlank) {
+        String value = props.getProperty(name, defaultValue);
+        if (defaultIfBlank && value != null && value.isBlank()) {
+            return defaultValue;
+        }
+        return value;
     }
 
     /**

--- a/src/main/resources/swing-extras/releaseNotes.txt
+++ b/src/main/resources/swing-extras/releaseNotes.txt
@@ -2,6 +2,7 @@ swing-extras Release Notes
 Author: Steve Corbett
 
 Version 2.8.0 [TODO release date]
+  #402 - Change unexpected behavior in Properties.getString()
   #399 - AppProperties: better subclass access to props dialog
   #398 - PropertiesDialog: ensure ActionPanel is scrollable
   #393 - Fix bug in ToggleableTabbedPane with L&F changes

--- a/src/test/java/ca/corbett/extras/properties/KeyStrokePropertyTest.java
+++ b/src/test/java/ca/corbett/extras/properties/KeyStrokePropertyTest.java
@@ -165,6 +165,32 @@ class KeyStrokePropertyTest extends AbstractPropertyBaseTests {
     }
 
     @Test
+    public void setReservedKeyStrokesAfterSave_withInitialBlankValue_shouldAllowSettingReservedKeyStrokes() {
+        // GIVEN a KeyStrokeProperty with no reserved keystrokes:
+        KeyStrokeProperty property = (KeyStrokeProperty)actual;
+        property.setReservedKeyStrokes(List.of());
+
+        // WHEN we save to properties:
+        Properties props = new Properties();
+        property.saveToProps(props);
+
+        // THEN the value stored in props should be an explicit blank String:
+        assertEquals("", props.getString(property.getFullyQualifiedName() + ".reservedKeyStrokes", "defaultValue"));
+
+        // WHEN we then set some reserved keystrokes on the property and load it:
+        KeyStroke reserved1 = KeyStrokeManager.parseKeyStroke("Ctrl+S");
+        KeyStroke reserved2 = KeyStrokeManager.parseKeyStroke("Ctrl+O");
+        property.setReservedKeyStrokes(List.of(reserved1, reserved2));
+        property.loadFromProps(props);
+
+        // THEN the reserved keystrokes should have replaced the explicit blank String from earlier:
+        List<KeyStroke> reserved = property.getReservedKeyStrokes();
+        assertEquals(2, reserved.size());
+        assertTrue(reserved.contains(reserved1));
+        assertTrue(reserved.contains(reserved2));
+    }
+
+    @Test
     public void addReservedKeyStrokes_withAdditionalKeyStrokes_shouldAddThem() {
         // GIVEN a KeyStrokeProperty with one reserved keystroke:
         KeyStrokeProperty property = (KeyStrokeProperty)actual;

--- a/src/test/java/ca/corbett/extras/properties/PropertiesTest.java
+++ b/src/test/java/ca/corbett/extras/properties/PropertiesTest.java
@@ -82,6 +82,32 @@ public class PropertiesTest {
         assertEquals(input.getSize(), actual.getSize());
     }
 
+    @Test
+    public void getString_withExplicitBlankStringAndDefaultGetStringMethod_shouldReturnBlank() {
+        // GIVEN a Properties instance where a string property is explicitly blank:
+        Properties props = new Properties();
+        props.setString("blankProp", "");
+
+        // WHEN we invoke the default getString() method with some non-blank default value:
+        String actual = props.getString("blankProp", "defaultValue");
+
+        // THEN we should receive the explicitly-stored blank value, NOT the default value:
+        assertEquals("", actual);
+    }
+
+    @Test
+    public void getString_withExplicitBlankStringAndOverloadedGetStringMethod_shouldReturnDefaultValue() {
+        // GIVEN a Properties instance where a string property is explicitly blank:
+        Properties props = new Properties();
+        props.setString("blankProp", "");
+
+        // WHEN we invoke the getString() overload and explicitly ask for blank values to be handled as nulls:
+        String actual = props.getString("blankProp", "defaultValue", true);
+
+        // THEN we should get the default value, and NOT the explicitly-stored blank value:
+        assertEquals("defaultValue", actual);
+    }
+
     private Properties createTestProps() {
         Properties prop1 = new Properties();
         prop1.setString("String", "string");
@@ -91,5 +117,4 @@ public class PropertiesTest {
         prop1.setColor("Color", Color.blue);
         return prop1;
     }
-
 }


### PR DESCRIPTION
This PR addresses issue #402 by correcting some unexpected behavior in `ca.corbett.extras.properties.Properties.getString()`.

Existing code should be unaffected! The problem was addressed by adding a new optional overload, so that two different code paths are offered. `KeyStrokeProperty` was updated to use the new overloaded method, and all other existing code should still receive the same behavior as before.

Added unit tests to characterize the problem and the solution. Verified that the new red/green test in `KeyStrokePropertyTest` was red before this fix and is now green with the fix in place.
