### PR TITLE
Issue #425 - better error handling in ImageUtil

### DIFF
--- a/src/main/java/ca/corbett/extras/image/ImageUtil.java
+++ b/src/main/java/ca/corbett/extras/image/ImageUtil.java
@@ -196,7 +196,7 @@ public class ImageUtil {
      *     so that callers can be assured that this method will either return non-null, or throw.
      * </p>
      *
-     * @param inStream The input stream in question. Must contain an image in a format supported by javax.imageio.ImageIo.
+     * @param inStream The input stream in question. Must contain an image in a format supported by javax.imageio.ImageIO.
      * @return A BufferedImage containing the image data.
      * @throws IOException If the image could not be loaded.
      */

--- a/src/main/java/ca/corbett/extras/image/ImageUtil.java
+++ b/src/main/java/ca/corbett/extras/image/ImageUtil.java
@@ -80,6 +80,7 @@ public class ImageUtil {
      *
      * @param file The File from which to load the image icon. Must not be null.
      * @return an ImageIcon instance.
+     * @throws IllegalArgumentException If {@code file} is {@code null}.
      * @throws IOException If the image could not be loaded.
      */
     public static ImageIcon loadImageIcon(final File file) throws IOException {
@@ -99,6 +100,7 @@ public class ImageUtil {
      *
      * @param url The URL from which to load the image icon. Must not be null.
      * @return an ImageIcon instance.
+     * @throws IllegalArgumentException If {@code url} is {@code null}.
      * @throws IOException If the image could not be loaded.
      */
     public static ImageIcon loadImageIcon(final URL url) throws IOException {

--- a/src/main/java/ca/corbett/extras/image/ImageUtil.java
+++ b/src/main/java/ca/corbett/extras/image/ImageUtil.java
@@ -220,8 +220,12 @@ public class ImageUtil {
      * @throws IOException If the image could not be loaded.
      */
     public static BufferedImage loadFromResource(Class<?> loadingClass, String resourceName) throws IOException {
-        try (InputStream inStream = loadingClass.getResourceAsStream(resourceName)) {
-            return loadImage(inStream);
+        InputStream inStream = loadingClass.getResourceAsStream(resourceName);
+        if (inStream == null) {
+            throw new IOException("Resource not found: " + resourceName + " for class " + loadingClass.getName());
+        }
+        try (InputStream is = inStream) {
+            return loadImage(is);
         }
     }
 

--- a/src/main/java/ca/corbett/extras/image/ImageUtil.java
+++ b/src/main/java/ca/corbett/extras/image/ImageUtil.java
@@ -78,11 +78,14 @@ public class ImageUtil {
      * ImagePanel has native support for animated GIF images, but you must
      * supply them as ImageIcon instances and not BufferedImage instances.
      *
-     * @param file The File from which to load the image icon.
+     * @param file The File from which to load the image icon. Must not be null.
      * @return an ImageIcon instance.
      * @throws IOException If the image could not be loaded.
      */
     public static ImageIcon loadImageIcon(final File file) throws IOException {
+        if (file == null) {
+            throw new IllegalArgumentException("File cannot be null");
+        }
         return validateImageIcon(new ImageIcon(file.getAbsolutePath()));
     }
 
@@ -94,11 +97,14 @@ public class ImageUtil {
      * ImagePanel has native support for animated GIF images, but you must
      * supply them as ImageIcon instances and not BufferedImage instances.
      *
-     * @param url The URL from which to load the image icon.
+     * @param url The URL from which to load the image icon. Must not be null.
      * @return an ImageIcon instance.
      * @throws IOException If the image could not be loaded.
      */
     public static ImageIcon loadImageIcon(final URL url) throws IOException {
+        if (url == null) {
+            throw new IllegalArgumentException("URL cannot be null");
+        }
         return validateImageIcon(new ImageIcon(url));
     }
 
@@ -110,19 +116,21 @@ public class ImageUtil {
      * This extra validation step intercepts the ImageIcon before we return it,
      * and adds an IOException if the image appears to be invalid.
      *
-     * @param image A candidate ImageIcon to evaluate.
+     * @param image A candidate ImageIcon to evaluate. Must not be null.
      * @return The input ImageIcon if it appears valid.
      * @throws IOException If the image appears to be invalid.
      */
     protected static ImageIcon validateImageIcon(final ImageIcon image) throws IOException {
+        if (image == null) {
+            throw new IllegalArgumentException("image cannot be null");
+        }
         // ImageIcon's getImageLoadStatus() method seems to be a bit flakey...
         // Some GIF files will return status ABORTED even though they display perfectly fine.
         // If we reject those here, we may end up rejecting valid images.
         // This makes it a bit tricky to determine whether the image actually loaded successfully.
         // The best we can do is to do some basic sanity checks on the image dimensions,
         // and then only reject images that have an explicit ERRORED status:
-        if (image == null
-                || image.getIconWidth() <= 0
+        if (image.getIconWidth() <= 0
                 || image.getIconHeight() <= 0
                 || image.getImageLoadStatus() == MediaTracker.ERRORED) {
             throw new IOException("Error loading ImageIcon");
@@ -134,35 +142,71 @@ public class ImageUtil {
 
     /**
      * Loads a BufferedImage from the specified URL.
+     * <p>
+     *     <b>NOTE:</b> Java's underlying ImageIO class can actually return null under some conditions,
+     *     if the image could not be loaded. This wrapper class will convert that into an IOException,
+     *     so that callers can be assured that this method will either return non-null, or throw.
+     * </p>
      *
      * @param url The URL of the image to load.
      * @return The BufferedImage contained in that URL.
      * @throws IOException If the image could not be loaded.
      */
     public static BufferedImage loadImage(final URL url) throws IOException {
-        return ImageIO.read(url);
+        if (url == null) {
+            throw new IllegalArgumentException("URL cannot be null");
+        }
+        BufferedImage image = ImageIO.read(url);
+        if (image == null) {
+            throw new IOException("Error loading image from URL: " + url);
+        }
+        return image;
     }
 
     /**
      * Loads a BufferedImage from the specified file.
+     * <p>
+     *     <b>NOTE:</b> Java's underlying ImageIO class can actually return null under some conditions,
+     *     if the image could not be loaded. This wrapper class will convert that into an IOException,
+     *     so that callers can be assured that this method will either return non-null, or throw.
+     * </p>
      *
      * @param file The file in question. Can be any format supported by javax.imageio.ImageIO.
      * @return A BufferedImage containing the image data.
      * @throws IOException If the image could not be loaded.
      */
     public static BufferedImage loadImage(final File file) throws IOException {
-        return ImageIO.read(file);
+        if (file == null) {
+            throw new IllegalArgumentException("File cannot be null");
+        }
+        BufferedImage image = ImageIO.read(file);
+        if (image == null) {
+            throw new IOException("Error loading image from file: " + file);
+        }
+        return image;
     }
 
     /**
      * Loads a BufferedImage from the specified input stream.
+     * <p>
+     *     <b>NOTE:</b> Java's underlying ImageIO class can actually return null under some conditions,
+     *     if the image could not be loaded. This wrapper class will convert that into an IOException,
+     *     so that callers can be assured that this method will either return non-null, or throw.
+     * </p>
      *
      * @param inStream The input stream in question. Must contain an image in a format supported by javax.imageio.ImageIo.
      * @return A BufferedImage containing the image data.
      * @throws IOException If the image could not be loaded.
      */
     public static BufferedImage loadImage(final InputStream inStream) throws IOException {
-        return ImageIO.read(inStream);
+        if (inStream == null) {
+            throw new IllegalArgumentException("inStream cannot be null");
+        }
+        BufferedImage image = ImageIO.read(inStream);
+        if (image == null) {
+            throw new IOException("Error loading image from stream: " + inStream);
+        }
+        return image;
     }
 
     /**
@@ -367,6 +411,11 @@ public class ImageUtil {
 
     /**
      * Converts the given byte array (created via serializeImage) back into a BufferedImage.
+     * <p>
+     *     <b>NOTE:</b> Java's underlying ImageIO class can actually return null under some conditions,
+     *     if the image could not be loaded. This wrapper class will convert that into an IOException,
+     *     so that callers can be assured that this method will either return non-null, or throw.
+     * </p>
      *
      * @param arr A byte array generated by one of the serializeImage methods.
      * @return A BufferedImage representing the image data, or null if the input array was null.
@@ -377,24 +426,29 @@ public class ImageUtil {
             return null;
         }
         ByteArrayInputStream is = new ByteArrayInputStream(arr);
-        return ImageIO.read(is);
+        return loadImage(is);
     }
 
     /**
      * Generates an image thumbnail for the given image file using the given dimensions.
      * Note that the image will be resized proportionally so that it fits inside the max of the
      * specified width and height. For example, an 800x600 image will be shrunk to 150x112.
+     * <p>
+     *     <b>NOTE:</b> Java's underlying ImageIO class can actually return null under some conditions,
+     *     if the image could not be loaded. This wrapper class will convert that into an IOException,
+     *     so that callers can be assured that this method will either return non-null, or throw.
+     * </p>
      *
-     * @param image  The image file in question. Can be any format supported by javax.imageio.ImageIO.
+     * @param file   The image file in question. Can be any format supported by javax.imageio.ImageIO.
      * @param width  The desired max width of the thumbnail.
      * @param height The desired max height of the thumbnail.
      * @return A BufferedImage containing the thumbnail.
      * @throws IOException on input/output error.
      */
-    public static BufferedImage generateThumbnail(final File image,
+    public static BufferedImage generateThumbnail(final File file,
                                                   final int width,
                                                   final int height) throws IOException {
-        BufferedImage sourceImage = ImageIO.read(image);
+        BufferedImage sourceImage = loadImage(file);
         return generateThumbnail(sourceImage, width, height);
     }
 
@@ -464,17 +518,22 @@ public class ImageUtil {
      * The resulting BufferedImage will be rendered with an alpha channel to preserve transparency.
      * Note that the image will be resized proportionally so that it fits inside the max of the
      * specified width and height. For example, an 800x600 image will be shrunk to 150x112.
+     * <p>
+     *     <b>NOTE:</b> Java's underlying ImageIO class can actually return null under some conditions,
+     *     if the image could not be loaded. This wrapper class will convert that into an IOException,
+     *     so that callers can be assured that this method will either return non-null, or throw.
+     * </p>
      *
-     * @param image  The image file in question. Can be any format supported by javax.imageio.ImageIO.
+     * @param file   The image file in question. Can be any format supported by javax.imageio.ImageIO.
      * @param width  The desired max width of the thumbnail.
      * @param height The desired max height of the thumbnail.
      * @return A BufferedImage containing the thumbnail.
      * @throws IOException on input/output error.
      */
-    public static BufferedImage generateThumbnailWithTransparency(final File image,
+    public static BufferedImage generateThumbnailWithTransparency(final File file,
                                                                   final int width,
                                                                   final int height) throws IOException {
-        BufferedImage sourceImage = ImageIO.read(image);
+        BufferedImage sourceImage = loadImage(file);
         return generateThumbnailWithTransparency(sourceImage, width, height);
     }
 
@@ -483,14 +542,20 @@ public class ImageUtil {
      * The resulting BufferedImage will be rendered with an alpha channel to preserve transparency.
      * The image will be resized proportionally to fit into the specified width and height.
      *
-     * @param sourceImage The image in question
-     * @param width       The desired max width of the thumbnail
-     * @param height      The desired max height of the thumbnail
+     * @param sourceImage The image in question. Must not be null.
+     * @param width       The desired max width of the thumbnail. Must be positive.
+     * @param height      The desired max height of the thumbnail. Must be positive.
      * @return A BufferedImage representing the thumbnail
      */
     public static BufferedImage generateThumbnailWithTransparency(final BufferedImage sourceImage,
                                                                   final int width,
                                                                   final int height) {
+        if (sourceImage == null) {
+            throw new IllegalArgumentException("sourceImage cannot be null");
+        }
+        if (width <= 0 || height <= 0) {
+            throw new IllegalArgumentException("width and height must be positive");
+        }
         int srcWidth = sourceImage.getWidth();
         int srcHeight = sourceImage.getHeight();
         float scaleFactor = (srcWidth > srcHeight)
@@ -523,11 +588,14 @@ public class ImageUtil {
      * This is useful for displaying basic information about an image without paying the computational
      * expense of actually loading the whole thing.
      *
-     * @param imageFile The image file in question. Must be in an image format supported by ImageIO.
+     * @param imageFile The image file in question. Must be in an image format supported by ImageIO. Can't be null.
      * @return The dimensions of the image.
      * @throws IOException for unsupported image formats, or if the file is corrupt or missing.
      */
     public static Dimension getImageDimensions(File imageFile) throws IOException {
+        if (imageFile == null) {
+            throw new IllegalArgumentException("imageFile cannot be null");
+        }
         try (ImageInputStream stream = ImageIO.createImageInputStream(imageFile)) {
             Iterator<ImageReader> readers = ImageIO.getImageReaders(stream);
 
@@ -554,8 +622,13 @@ public class ImageUtil {
      * versus height. A "fuzzy" percentage is applied, such that images don't need to be exactly
      * square to be considered "square". For example, an image of 999x1000 is technically portrait,
      * but really, it could be considered "close enough" to be called square.
+     *
+     * @param imageDim The dimensions of the image in question. Must not be null.
      */
     public static String getAspectRatioDescription(Dimension imageDim) {
+        if (imageDim == null) {
+            throw new IllegalArgumentException("imageDim cannot be null");
+        }
         final double TOLERANCE = 0.05; // five percent is "close enough"
         int width = imageDim.width;
         int height = imageDim.height;
@@ -589,7 +662,7 @@ public class ImageUtil {
      *     force the resulting image to be square.
      * </p>
      *
-     * @param image        The image to scale.
+     * @param image        The image to scale. Must not be null.
      * @param maxDimension The desired largest dimension of the scaled image.
      * @return The scaled image.
      */
@@ -611,12 +684,18 @@ public class ImageUtil {
      * and height are equal, but without distorting the image itself.
      * </p>
      *
-     * @param image        The image to scale.
-     * @param maxDimension The desired largest dimension of the scaled image.
+     * @param image        The image to scale. Must not be null.
+     * @param maxDimension The desired largest dimension of the scaled image. Must be positive.
      * @param makeSquare   If true, will apply transparent padding if needed so the returned image is square.
      * @return The scaled image.
      */
     public static BufferedImage scaleImageToFitSquareBounds(BufferedImage image, int maxDimension, boolean makeSquare) {
+        if (image == null) {
+            throw new IllegalArgumentException("image cannot be null");
+        }
+        if (maxDimension <= 0) {
+            throw new IllegalArgumentException("maxDimension must be positive");
+        }
         int originalWidth = image.getWidth();
         int originalHeight = image.getHeight();
 
@@ -698,11 +777,17 @@ public class ImageUtil {
      * PNG is a lossless format that supports transparency, making it ideal for graphics,
      * screenshots, and images that require an alpha channel.
      *
-     * @param image The BufferedImage to save.
-     * @param file  The File to which to save.
+     * @param image The BufferedImage to save. Must not be null.
+     * @param file  The File to which to save. Must not be null.
      * @throws IOException If the image could not be saved or if no PNG writer is available.
      */
     public static void savePngImage(final BufferedImage image, final File file) throws IOException {
+        if (image == null) {
+            throw new IllegalArgumentException("image cannot be null");
+        }
+        if (file == null) {
+            throw new IllegalArgumentException("file cannot be null");
+        }
         Iterator<ImageWriter> iter = ImageIO.getImageWritersByFormatName("png");
         ImageWriter imageWriter = null;
         if (iter.hasNext()) {

--- a/src/main/resources/swing-extras/releaseNotes.txt
+++ b/src/main/resources/swing-extras/releaseNotes.txt
@@ -2,6 +2,7 @@ swing-extras Release Notes
 Author: Steve Corbett
 
 Version 2.9.0 [TODO release date] - Maintenance release
+  #425 - Better ImageIO wrapping and error handling in ImageUtil
 
 Version 2.8.0 [2026-03-08] - ActionPanel, TextInputDialog
   #417 - DirTree: add support for file viewing in the tree

--- a/src/test/java/ca/corbett/extras/image/ImageUtilTest.java
+++ b/src/test/java/ca/corbett/extras/image/ImageUtilTest.java
@@ -11,7 +11,10 @@ import java.awt.MediaTracker;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.when;
 
@@ -26,15 +29,7 @@ public class ImageUtilTest {
 
     @Test
     public void validateImageIcon_withNullImage_shouldThrow() {
-        try {
-            // GIVEN a null image:
-            // WHEN we try to validate it:
-            // THEN we should get an IOException:
-            ImageUtil.validateImageIcon(null);
-            fail("Expected exception but didn't get one!");
-        }
-        catch (IOException ignored) {
-        }
+        assertThrows(IllegalArgumentException.class, () -> ImageUtil.validateImageIcon(null));
     }
 
     @Test
@@ -45,13 +40,8 @@ public class ImageUtilTest {
         when(mockedImageIcon.getImageLoadStatus()).thenReturn(MediaTracker.COMPLETE); // valid
 
         // WHEN we try to validate it:
-        try {
-            // THEN we should get an IOException:
-            ImageUtil.validateImageIcon(mockedImageIcon);
-            fail("Expected exception but didn't get one!");
-        }
-        catch (IOException ignored) {
-        }
+        // THEN we should get an IOException:
+        assertThrows(IOException.class, () -> ImageUtil.validateImageIcon(mockedImageIcon));
     }
 
     @Test
@@ -62,13 +52,8 @@ public class ImageUtilTest {
         when(mockedImageIcon.getImageLoadStatus()).thenReturn(MediaTracker.COMPLETE); // valid
 
         // WHEN we try to validate it:
-        try {
-            // THEN we should get an IOException:
-            ImageUtil.validateImageIcon(mockedImageIcon);
-            fail("Expected exception but didn't get one!");
-        }
-        catch (IOException ignored) {
-        }
+        // THEN we should get an IOException:
+        assertThrows(IOException.class, () -> ImageUtil.validateImageIcon(mockedImageIcon));
     }
 
     @Test
@@ -83,8 +68,8 @@ public class ImageUtilTest {
             // THEN it should pass without exception:
             ImageUtil.validateImageIcon(mockedImageIcon);
         }
-        catch (IOException ignored) {
-            fail("Did not expect an exception but got one!");
+        catch (IOException ioe) {
+            fail("Did not expect an exception but got: " + ioe.getMessage());
         }
     }
 
@@ -100,8 +85,8 @@ public class ImageUtilTest {
             // THEN it should pass without exception:
             ImageUtil.validateImageIcon(mockedImageIcon);
         }
-        catch (IOException ignored) {
-            fail("Did not expect an exception but got one!");
+        catch (IOException ioe) {
+            fail("Did not expect an exception but got: " + ioe.getMessage());
         }
     }
 
@@ -113,17 +98,12 @@ public class ImageUtilTest {
         when(mockedImageIcon.getImageLoadStatus()).thenReturn(MediaTracker.ERRORED); // invalid!
 
         // WHEN we try to validate it:
-        try {
-            // THEN we should get an IOException:
-            ImageUtil.validateImageIcon(mockedImageIcon);
-            fail("Expected exception but didn't get one!");
-        }
-        catch (IOException ignored) {
-        }
+        // THEN it should pass without exception:
+        assertThrows(IOException.class, () -> ImageUtil.validateImageIcon(mockedImageIcon));
     }
 
     @Test
-    public void savePngImage_withValidImage_shouldSave() throws Exception {
+    public void savePngImage_withValidImage_shouldSave() {
         // GIVEN a valid image:
         BufferedImage image = new BufferedImage(100, 100, BufferedImage.TYPE_INT_ARGB);
         Graphics2D g = image.createGraphics();
@@ -131,24 +111,160 @@ public class ImageUtilTest {
         g.fillRect(0, 0, 100, 100);
         g.dispose();
 
+        try {
+            // WHEN we try to save it as PNG:
+            File tempFile = File.createTempFile("testImage", ".png");
+            tempFile.deleteOnExit();
+            ImageUtil.savePngImage(image, tempFile);
+
+            // THEN it should save without exception and the file should exist:
+            if (!tempFile.exists()) {
+                fail("Expected file to be created but it doesn't exist!");
+            }
+
+            // AND We should be able to load it back without exception:
+            BufferedImage loadedImage = ImageUtil.loadImage(tempFile);
+
+            // Clean up
+            image.flush();
+            loadedImage.flush();
+        }
+        catch (IOException ioe) {
+            fail("Expected to save and load the image without exception but got: " + ioe.getMessage());
+        }
+    }
+
+    @Test
+    public void loadImage_withNullStream_shouldThrow() {
+        // GIVEN a null stream:
+        // WHEN we try to load an image from it:
+        // THEN we should get an IllegalArgumentException:
+        assertThrows(IllegalArgumentException.class, () -> ImageUtil.loadImage((InputStream)null));
+    }
+
+    @Test
+    public void loadImage_withNullFile_shouldThrow() {
+        // GIVEN a null file:
+        // WHEN we try to load an image from it:
+        // THEN we should get an IllegalArgumentException:
+        assertThrows(IllegalArgumentException.class, () -> ImageUtil.loadImage((File)null));
+    }
+
+    @Test
+    public void loadImage_withNullURL_shouldThrow() {
+        // GIVEN a null URL:
+        // WHEN we try to load an image from it:
+        // THEN we should get an IllegalArgumentException:
+        assertThrows(IllegalArgumentException.class, () -> ImageUtil.loadImage((URL)null));
+    }
+
+    @Test
+    public void generateThumbnailWithTransparency_withNullFile_shouldThrow() {
+        // GIVEN a null file:
+        // WHEN we try to generate a thumbnail from it:
+        // THEN we should get an IllegalArgumentException:
+        assertThrows(IllegalArgumentException.class, () -> ImageUtil.generateThumbnailWithTransparency(
+                (File)null, 50, 50));
+    }
+
+    @Test
+    public void savePngImage_withNullImage_shouldThrow() {
+        // GIVEN a null image:
         // WHEN we try to save it as PNG:
-        File tempFile = File.createTempFile("testImage", ".png");
-        tempFile.deleteOnExit();
-        ImageUtil.savePngImage(image, tempFile);
+        // THEN we should get an IllegalArgumentException:
+        assertThrows(IllegalArgumentException.class, () -> ImageUtil.savePngImage(
+                null, new File("dummy.png")));
+    }
 
-        // THEN it should save without exception and the file should exist:
-        if (!tempFile.exists()) {
-            fail("Expected file to be created but it doesn't exist!");
-        }
+    @Test
+    public void savePngImage_withNullFile_shouldThrow() {
+        // GIVEN a null file:
+        // WHEN we try to save an image as PNG to it:
+        // THEN we should get an IOException:
+        BufferedImage dummyImage = new BufferedImage(10, 10, BufferedImage.TYPE_INT_ARGB);
+        assertThrows(IllegalArgumentException.class, () -> ImageUtil.savePngImage(dummyImage, null));
+    }
 
-        // AND We should be able to load it back:
-        BufferedImage loadedImage = ImageUtil.loadImage(tempFile);
-        if (loadedImage == null) {
-            fail("Expected to load the saved image but got null!");
-        }
+    @Test
+    public void loadImageIcon_withNullFile_shouldThrow() {
+        // GIVEN a null file:
+        // WHEN we try to load an ImageIcon from it:
+        // THEN we should get an IllegalArgumentException:
+        assertThrows(IllegalArgumentException.class, () -> ImageUtil.loadImageIcon((File) null));
+    }
 
-        // Clean up
-        image.flush();
-        loadedImage.flush();
+    @Test
+    public void loadImageIcon_withNullURL_shouldThrow() {
+        // GIVEN a null URL:
+        // WHEN we try to load an ImageIcon from it:
+        // THEN we should get an IllegalArgumentException:
+        assertThrows(IllegalArgumentException.class, () -> ImageUtil.loadImageIcon((URL) null));
+    }
+
+    @Test
+    public void generateThumbnailWithTransparency_withNullImage_shouldThrow() {
+        // GIVEN a null BufferedImage:
+        // WHEN we try to generate a thumbnail from it:
+        // THEN we should get an IllegalArgumentException:
+        assertThrows(IllegalArgumentException.class,
+                () -> ImageUtil.generateThumbnailWithTransparency((BufferedImage) null, 50, 50));
+    }
+
+    @Test
+    public void generateThumbnailWithTransparency_withNonPositiveWidth_shouldThrow() {
+        // GIVEN a valid image but a non-positive width:
+        BufferedImage dummyImage = new BufferedImage(100, 100, BufferedImage.TYPE_INT_ARGB);
+
+        // WHEN we try to generate a thumbnail with width=0:
+        // THEN we should get an IllegalArgumentException:
+        assertThrows(IllegalArgumentException.class,
+                () -> ImageUtil.generateThumbnailWithTransparency(dummyImage, 0, 50));
+    }
+
+    @Test
+    public void generateThumbnailWithTransparency_withNonPositiveHeight_shouldThrow() {
+        // GIVEN a valid image but a non-positive height:
+        BufferedImage dummyImage = new BufferedImage(100, 100, BufferedImage.TYPE_INT_ARGB);
+
+        // WHEN we try to generate a thumbnail with height=0:
+        // THEN we should get an IllegalArgumentException:
+        assertThrows(IllegalArgumentException.class,
+                () -> ImageUtil.generateThumbnailWithTransparency(dummyImage, 50, 0));
+    }
+
+    @Test
+    public void getImageDimensions_withNullFile_shouldThrow() {
+        // GIVEN a null file:
+        // WHEN we try to get image dimensions from it:
+        // THEN we should get an IllegalArgumentException:
+        assertThrows(IllegalArgumentException.class, () -> ImageUtil.getImageDimensions(null));
+    }
+
+    @Test
+    public void getAspectRatioDescription_withNullDimension_shouldThrow() {
+        // GIVEN a null Dimension:
+        // WHEN we try to get an aspect ratio description from it:
+        // THEN we should get an IllegalArgumentException:
+        assertThrows(IllegalArgumentException.class, () -> ImageUtil.getAspectRatioDescription(null));
+    }
+
+    @Test
+    public void scaleImageToFitSquareBounds_withNullImage_shouldThrow() {
+        // GIVEN a null image:
+        // WHEN we try to scale it:
+        // THEN we should get an IllegalArgumentException:
+        assertThrows(IllegalArgumentException.class,
+                () -> ImageUtil.scaleImageToFitSquareBounds(null, 100));
+    }
+
+    @Test
+    public void scaleImageToFitSquareBounds_withNonPositiveMaxDimension_shouldThrow() {
+        // GIVEN a valid image but a non-positive maxDimension:
+        BufferedImage dummyImage = new BufferedImage(100, 100, BufferedImage.TYPE_INT_ARGB);
+
+        // WHEN we try to scale it with maxDimension=0:
+        // THEN we should get an IllegalArgumentException:
+        assertThrows(IllegalArgumentException.class,
+                () -> ImageUtil.scaleImageToFitSquareBounds(dummyImage, 0));
     }
 }

--- a/src/test/java/ca/corbett/extras/image/ImageUtilTest.java
+++ b/src/test/java/ca/corbett/extras/image/ImageUtilTest.java
@@ -98,7 +98,7 @@ public class ImageUtilTest {
         when(mockedImageIcon.getImageLoadStatus()).thenReturn(MediaTracker.ERRORED); // invalid!
 
         // WHEN we try to validate it:
-        // THEN it should pass without exception:
+        // THEN we should get an IOException:
         assertThrows(IOException.class, () -> ImageUtil.validateImageIcon(mockedImageIcon));
     }
 

--- a/src/test/java/ca/corbett/extras/image/ImageUtilTest.java
+++ b/src/test/java/ca/corbett/extras/image/ImageUtilTest.java
@@ -180,7 +180,7 @@ public class ImageUtilTest {
     public void savePngImage_withNullFile_shouldThrow() {
         // GIVEN a null file:
         // WHEN we try to save an image as PNG to it:
-        // THEN we should get an IOException:
+        // THEN we should get an IllegalArgumentException:
         BufferedImage dummyImage = new BufferedImage(10, 10, BufferedImage.TYPE_INT_ARGB);
         assertThrows(IllegalArgumentException.class, () -> ImageUtil.savePngImage(dummyImage, null));
     }


### PR DESCRIPTION
This PR addresses issue #425 by tightening up error handling in ImageUtil, and also adding a non-null return guarantee to the `loadImage` methods, which previously might unexpectedly return `null`. Updated the method javadocs with the new "return or throw" expectation.

Specific changes in this PR:
- better error handling in general. Any obviously wrong input parameter (null objects, non-positive image dimensions) will now throw `IllegalArgumentException` immediately.
- better unit tests. Now using `assertThrows` for more compact tests.

The changes to error handling may be a breaking change for some client applications, if they relied on the previous "loadImage may return null" behavior. The release announcement for the upcoming 2.9 release will mention this specifically.