### PR TITLE
Issue #433 - don't block the EDT in UpdateManager when executing shutdown hooks

### DIFF
--- a/src/main/java/ca/corbett/updates/UpdateManager.java
+++ b/src/main/java/ca/corbett/updates/UpdateManager.java
@@ -22,6 +22,7 @@ import java.security.PublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -83,7 +84,7 @@ public class UpdateManager {
 
     protected final UpdateSources updateSources;
     protected final List<UpdateManagerListener> listeners = new ArrayList<>();
-    protected final List<ShutdownHook> shutdownHooks = new ArrayList<>();
+    protected final List<ShutdownHook> shutdownHooks = new CopyOnWriteArrayList<>();
     protected final DownloadManager downloadManager;
     protected VersionManifest versionManifest;
 
@@ -273,6 +274,21 @@ public class UpdateManager {
     /**
      * Register to receive notification before the application is restarted to pick up
      * changes caused by extensions being installed or uninstalled.
+     * <p>
+     *     <b>IMPORTANT NOTE:</b> Your shutdown hook will be invoked on a worker thread, NOT the Swing EDT!
+     *     If your shutdown hooks need to do anything UI-related,
+     *     for example showing a popup dialog to prompt the user about unsaved changes,
+     *     then you should use SwingUtilities.invokeAndWait() inside your shutdown hook.
+     *     This serves two important purposes:
+     * </p>
+     * <ol>
+     *     <li>Avoids thread problems with Java Swing, because Java Swing is not thread safe by default.</li>
+     *     <li>Using invokeAndWait() instead of invokeLater() ensures that your shutdown hook
+     *     does not return until it is actually finished. This is important because as soon as the
+     *     last shutdown hook returns, System.exit() is invoked, and the application terminates.
+     *     If you use invokeLater(), it's likely that your hook will return before the work
+     *     is done.</li>
+     * </ol>
      */
     public void registerShutdownHook(ShutdownHook hook) {
         shutdownHooks.add(hook);
@@ -291,6 +307,21 @@ public class UpdateManager {
      * If you have cleanup that needs to be done before a restart (closing open
      * db connections, saving unsaved changes, etc), you should use registerShutdownHook
      * so that your cleanup code can be executed before a restart!
+     * <p>
+     *     <b>IMPORTANT NOTE:</b> Your shutdown hook will be invoked on a worker thread, NOT the Swing EDT!
+     *     If your shutdown hooks need to do anything UI-related,
+     *     for example showing a popup dialog to prompt the user about unsaved changes,
+     *     then you should use SwingUtilities.invokeAndWait() inside your shutdown hook.
+     *     This serves two important purposes:
+     * </p>
+     * <ol>
+     *     <li>Avoids thread problems with Java Swing, because Java Swing is not thread safe by default.</li>
+     *     <li>Using invokeAndWait() instead of invokeLater() ensures that your shutdown hook
+     *     does not return until it is actually finished. This is important because as soon as the
+     *     last shutdown hook returns, System.exit() is invoked, and the application terminates.
+     *     If you use invokeLater(), it's likely that your hook will return before the work
+     *     is done.</li>
+     * </ol>
      */
     public void restartApplication() {
         log.info("Restarting application...");

--- a/src/main/java/ca/corbett/updates/UpdateManager.java
+++ b/src/main/java/ca/corbett/updates/UpdateManager.java
@@ -8,6 +8,7 @@ import ca.corbett.extras.io.DownloadThread;
 import com.google.gson.JsonSyntaxException;
 
 import javax.swing.JOptionPane;
+import javax.swing.SwingUtilities;
 import java.awt.Component;
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -293,8 +294,23 @@ public class UpdateManager {
      */
     public void restartApplication() {
         log.info("Restarting application...");
-        executeShutdownHooks();
-        System.exit(APPLICATION_RESTART);
+
+        // If we are on the Swing EDT, we must NOT block it while waiting for shutdown hooks to finish.
+        // Blocking the EDT would prevent any shutdown hook from doing UI work (e.g. showing a JOptionPane
+        // to ask the user about unsaved changes). Instead, hand off the whole sequence to a dedicated
+        // non-daemon thread so the EDT stays responsive, then exit from that thread when ready.
+        if (SwingUtilities.isEventDispatchThread()) {
+            Thread restartThread = new Thread(() -> {
+                executeShutdownHooks();
+                System.exit(APPLICATION_RESTART);
+            }, "swing-extras-restart");
+            restartThread.setDaemon(false); // keep the JVM alive until this thread finishes
+            restartThread.start();
+        }
+        else {
+            executeShutdownHooks();
+            System.exit(APPLICATION_RESTART);
+        }
     }
 
     /**

--- a/src/main/resources/swing-extras/releaseNotes.txt
+++ b/src/main/resources/swing-extras/releaseNotes.txt
@@ -3,12 +3,12 @@ Author: Steve Corbett
 
 Version 2.9.0 [TODO release date] - Maintenance release
   #433 - Fix threading issue in UpdateManager's shutdown hooks
+  #422 - Fix theme misclassification issue in LookAndFeelManager
   #430 - AppProperties.peek() now accepts an optional default value
   #425 - Better ImageIO wrapping and error handling in ImageUtil
   #424 - Hit ESC to close the image list panel's preview popup
 
 Version 2.8.0 [2026-03-08] - ActionPanel, TextInputDialog
-  #422 - Fix theme misclassification issue in LookAndFeelManager
   #417 - DirTree: add support for file viewing in the tree
   #415 - BlurLayerUI: support multi-line text overlay
   #410 - ActionPanel: add buttonPadding option, fix action gaps

--- a/src/main/resources/swing-extras/releaseNotes.txt
+++ b/src/main/resources/swing-extras/releaseNotes.txt
@@ -2,6 +2,7 @@ swing-extras Release Notes
 Author: Steve Corbett
 
 Version 2.9.0 [TODO release date] - Maintenance release
+  #433 - Fix threading issue in UpdateManager's shutdown hooks
   #430 - AppProperties.peek() now accepts an optional default value
   #425 - Better ImageIO wrapping and error handling in ImageUtil
   #424 - Hit ESC to close the image list panel's preview popup


### PR DESCRIPTION
This PR addresses issue #433 by fixing a critical bug in `UpdateManager`. Previously, if `restartApplication` was invoked from the Swing EDT, UpdateManager would block the EDT while executing shutdown hooks, thereby preventing those hooks from doing anything UI-related. Shutdown hooks often need to use `JOptionPane` to prompt the user about unsaved changes, or handle things like closing dialogs or popup windows. It is therefore important not to block the EDT while we wait for shutdown hooks to execute, because the chance of deadlocks occurring is high.
