### PR TITLE
Issue #422 - darcula, dracula, what's the difference

### DIFF
--- a/src/main/java/ca/corbett/extras/LookAndFeelManager.java
+++ b/src/main/java/ca/corbett/extras/LookAndFeelManager.java
@@ -272,11 +272,11 @@ public class LookAndFeelManager {
 
         // We *could* spot-check some RGB values in the current LaF and make
         // a proper guess as to whether it's "light" or "dark", but this seems
-        // pretty error-prone. So, eh, let's just look for "dark" in the
-        // name and call it a day. Any theme that doesn't explicitly have
-        // "dark" in the name is probably a light theme.
+        // pretty error-prone. So, eh, let's just look for "dark" or other
+        // dark-seeming terms in the name and call it a day.
+        // Any theme that doesn't match this check is *probably* a light theme.
         return combinedName.contains("dark")
-                || combinedName.contains("darc") // don't forget about "darcula"!
+                || combinedName.contains("dracula") // we have two dark themes with "dracula" in the name
                 || combinedName.contains("matrix") // No LaF that I currently know of, but it makes sense to me :)
                 || combinedName.contains("hiberbee") // Hiberbee is a dark theme but doesn't have "dark" in the name
                 || combinedName.contains("noir")  // anything with "noir"/"noire"

--- a/src/main/resources/swing-extras/releaseNotes.txt
+++ b/src/main/resources/swing-extras/releaseNotes.txt
@@ -2,6 +2,7 @@ swing-extras Release Notes
 Author: Steve Corbett
 
 Version 2.8.0 [2026-03-08] - ActionPanel, TextInputDialog
+  #422 - Fix theme misclassification issue in LookAndFeelManager
   #417 - DirTree: add support for file viewing in the tree
   #415 - BlurLayerUI: support multi-line text overlay
   #410 - ActionPanel: add buttonPadding option, fix action gaps


### PR DESCRIPTION
This PR fixes a minor issue described in #422 - there are no supported Look and Feels named "darcula", but there are two themes with "dracula" in the name. Those dark "dracula" themes were being misclassified as "light" themes, because of this code that was checking for the wrong name.
