### PR TITLE
Issue #437 - Add FallbackExceptionHandler

### DIFF
--- a/src/main/java/ca/corbett/extras/FallbackExceptionHandler.java
+++ b/src/main/java/ca/corbett/extras/FallbackExceptionHandler.java
@@ -27,7 +27,9 @@ public class FallbackExceptionHandler implements Thread.UncaughtExceptionHandler
 
     @Override
     public void uncaughtException(Thread t, Throwable e) {
-        log.log(Level.SEVERE, "Uncaught exception in thread " + t.getName() + ": " + e.getMessage(), e);
+        String exType = e.getClass().getSimpleName();
+        String exMsg = e.getMessage() == null ? e.toString() : e.getMessage();
+        log.log(Level.SEVERE, "Uncaught " + exType + " in thread " + t.getName() + ": " + exMsg, e);
     }
 
     /**

--- a/src/main/java/ca/corbett/extras/FallbackExceptionHandler.java
+++ b/src/main/java/ca/corbett/extras/FallbackExceptionHandler.java
@@ -1,0 +1,40 @@
+package ca.corbett.extras;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Fallback handler for any exception that goes uncaught in any thread.
+ * This class ensures that the exception gets logged with the full stack trace.
+ * By default, uncaught exceptions print a stack trace to the console, but that
+ * is not helpful if the application wasn't started via a terminal.
+ * <p>
+ * Use the static register() method to set this as the default uncaught
+ * exception handler for all threads in your application startup code.
+ * </p>
+ * <p>
+ * Note that this handler will only be used if the current Thread
+ * and/or ThreadGroup does not have its own uncaught exception handler.
+ * This class represents a last-ditch fallback.
+ * </p>
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ * @since swing-extras 2.9
+ */
+public class FallbackExceptionHandler implements Thread.UncaughtExceptionHandler {
+
+    private static final Logger log = Logger.getLogger(FallbackExceptionHandler.class.getName());
+
+    @Override
+    public void uncaughtException(Thread t, Throwable e) {
+        log.log(Level.SEVERE, "Uncaught exception in thread " + t.getName() + ": " + e.getMessage(), e);
+    }
+
+    /**
+     * Registers an instance of this handler as the default
+     * uncaught exception handler for all threads in the application.
+     */
+    public static void register() {
+        Thread.setDefaultUncaughtExceptionHandler(new FallbackExceptionHandler());
+    }
+}

--- a/src/main/java/ca/corbett/extras/demo/DemoAppLauncher.java
+++ b/src/main/java/ca/corbett/extras/demo/DemoAppLauncher.java
@@ -16,6 +16,9 @@ import java.awt.SplashScreen;
 public class DemoAppLauncher {
     public static void main(String[] args) {
 
+        // Register a FallbackExceptionHandler to catch any uncaught exceptions and log them properly:
+        FallbackExceptionHandler.register();
+
         LookAndFeelManager.installExtraLafs();
         LookAndFeelManager.switchLaf(FlatLightLaf.class.getName());
 
@@ -31,9 +34,6 @@ public class DemoAppLauncher {
             }
             splashScreen.close();
         }
-
-        // Register a FallbackExceptionHandler to catch any uncaught exceptions and log them properly:
-        FallbackExceptionHandler.register();
 
         // Create and display the form
         EventQueue.invokeLater(() -> DemoApp.getInstance().setVisible(true));

--- a/src/main/java/ca/corbett/extras/demo/DemoAppLauncher.java
+++ b/src/main/java/ca/corbett/extras/demo/DemoAppLauncher.java
@@ -1,8 +1,10 @@
 package ca.corbett.extras.demo;
 
+import ca.corbett.extras.FallbackExceptionHandler;
 import ca.corbett.extras.LookAndFeelManager;
 import com.formdev.flatlaf.FlatLightLaf;
 
+import java.awt.EventQueue;
 import java.awt.SplashScreen;
 
 /**
@@ -30,7 +32,10 @@ public class DemoAppLauncher {
             splashScreen.close();
         }
 
+        // Register a FallbackExceptionHandler to catch any uncaught exceptions and log them properly:
+        FallbackExceptionHandler.register();
+
         // Create and display the form
-        java.awt.EventQueue.invokeLater(() -> DemoApp.getInstance().setVisible(true));
+        EventQueue.invokeLater(() -> DemoApp.getInstance().setVisible(true));
     }
 }

--- a/src/main/resources/swing-extras/releaseNotes.txt
+++ b/src/main/resources/swing-extras/releaseNotes.txt
@@ -2,6 +2,7 @@ swing-extras Release Notes
 Author: Steve Corbett
 
 Version 2.9.0 [TODO release date] - Maintenance release
+  #437 - New convenience class: FallbackExceptionHandler
   #433 - Fix threading issue in UpdateManager's shutdown hooks
   #422 - Fix theme misclassification issue in LookAndFeelManager
   #430 - AppProperties.peek() now accepts an optional default value


### PR DESCRIPTION
This PR addresses issue #437 by adding a `FallbackExceptionHandler` convenience class that applications can use to ensure that uncaught exceptions get logged properly, with full stack trace. 

Added this to the built-in demo application as an example of proper usage.