### PR TITLE
Issue #431 - FileField - allow chooser button customization

### DIFF
--- a/src/main/java/ca/corbett/forms/fields/FileField.java
+++ b/src/main/java/ca/corbett/forms/fields/FileField.java
@@ -13,6 +13,7 @@ import ca.corbett.forms.validators.FileMustNotExistValidator;
 
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
+import javax.swing.Icon;
 import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JFileChooser;
@@ -44,6 +45,14 @@ import java.util.List;
  * The underlying JFileChooser is not directly exposed, but there are some
  * convenience methods here, like setFileFilter(), that can be used to
  * customize it.
+ * </p>
+ * <p>
+ *     The chooser button displays simple text "Choose..." by default, but you
+ *     can change this text with the setButtonText() method.
+ *     You can also opt for an icon instead of text for this button,
+ *     by calling setButtonIcon() - the chooser button will be resized to fit your icon,
+ *     and the text will be removed.
+ * </p>
  *
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
  * @since 2019-11-24
@@ -119,6 +128,43 @@ public final class FileField extends FormField implements DocumentListener {
         chooseButton.setPreferredSize(new Dimension(105, 22));
         dirPanel.add(chooseButton);
         fieldComponent = dirPanel;
+    }
+
+    /**
+     * Changes our chooser button to use the given icon. The button will be resized to fit the icon,
+     * and the button text will be removed. A tooltip will be added automatically.
+     * If the supplied icon is null, this request is ignored. To revert to using text
+     * instead of an icon, call setButtonText().
+     *
+     * @param icon Any icon to use for the button. Must not be null.
+     * @return This FileField, for chaining.
+     */
+    public FileField setButtonIcon(Icon icon) {
+        if (icon != null) {
+            chooseButton.setText("");
+            chooseButton.setToolTipText("Choose...");
+            chooseButton.setIcon(icon);
+            chooseButton.setPreferredSize(new Dimension(icon.getIconWidth() + 4, icon.getIconHeight() + 4));
+        }
+        return this;
+    }
+
+    /**
+     * Sets the text to use for the button. If the supplied text is null, this request is ignored.
+     * To use an icon instead of text, call setButtonIcon(). Note that if you switch back to using text,
+     * any icon that was previously set will be removed, and the button will be resized to fit the text.
+     *
+     * @param text Any text to use for the button. Must not be null. Button will be resized to fit the text.
+     * @return This FileField, for chaining.
+     */
+    public FileField setButtonText(String text) {
+        if (text != null) {
+            chooseButton.setText(text);
+            chooseButton.setToolTipText(null);
+            chooseButton.setIcon(null);
+            chooseButton.setPreferredSize(null);
+        }
+        return this;
     }
 
     /**

--- a/src/main/java/ca/corbett/forms/fields/FileField.java
+++ b/src/main/java/ca/corbett/forms/fields/FileField.java
@@ -136,7 +136,7 @@ public final class FileField extends FormField implements DocumentListener {
      * If the supplied icon is null, this request is ignored. To revert to using text
      * instead of an icon, call setButtonText().
      *
-     * @param icon Any icon to use for the button. Must not be null.
+     * @param icon Any icon to use for the button. If null, this request is ignored.
      * @return This FileField, for chaining.
      */
     public FileField setButtonIcon(Icon icon) {
@@ -144,7 +144,9 @@ public final class FileField extends FormField implements DocumentListener {
             chooseButton.setText("");
             chooseButton.setToolTipText("Choose...");
             chooseButton.setIcon(icon);
-            chooseButton.setPreferredSize(new Dimension(icon.getIconWidth() + 4, icon.getIconHeight() + 4));
+            chooseButton.setPreferredSize(null); // let the button resize to fit the icon
+            getFieldComponent().invalidate();
+            getFieldComponent().repaint();
         }
         return this;
     }
@@ -154,7 +156,7 @@ public final class FileField extends FormField implements DocumentListener {
      * To use an icon instead of text, call setButtonIcon(). Note that if you switch back to using text,
      * any icon that was previously set will be removed, and the button will be resized to fit the text.
      *
-     * @param text Any text to use for the button. Must not be null. Button will be resized to fit the text.
+     * @param text Any text to use for the button. If null, this request is ignored.
      * @return This FileField, for chaining.
      */
     public FileField setButtonText(String text) {
@@ -163,6 +165,8 @@ public final class FileField extends FormField implements DocumentListener {
             chooseButton.setToolTipText(null);
             chooseButton.setIcon(null);
             chooseButton.setPreferredSize(null);
+            getFieldComponent().invalidate();
+            getFieldComponent().repaint();
         }
         return this;
     }

--- a/src/main/resources/swing-extras/releaseNotes.txt
+++ b/src/main/resources/swing-extras/releaseNotes.txt
@@ -4,6 +4,7 @@ Author: Steve Corbett
 Version 2.9.0 [TODO release date] - Maintenance release
   #437 - New convenience class: FallbackExceptionHandler
   #433 - Fix threading issue in UpdateManager's shutdown hooks
+  #431 - FileField: allow customization of chooser button
   #422 - Fix theme misclassification issue in LookAndFeelManager
   #430 - AppProperties.peek() now accepts an optional default value
   #425 - Better ImageIO wrapping and error handling in ImageUtil


### PR DESCRIPTION
This PR addresses issue #431 by allowing customization of the chooser button in `FileField`. Previously, hard-coded text of "Choose..." was used for the label, with no way of adjusting the displayed text, and no way to use a more compact icon instead of text. Now, callers can choose between the default text (behavior unchanged from before), or setting custom text, or supplying an icon.