### PR TITLE
Issue #421 - ActionPanel: fix flat button border problem

### DIFF
--- a/src/main/java/ca/corbett/extras/actionpanel/ActionPanel.java
+++ b/src/main/java/ca/corbett/extras/actionpanel/ActionPanel.java
@@ -1829,7 +1829,7 @@ public class ActionPanel extends JPanel {
         // Special case "flat buttons" because their default border handling is very stupid.
         // (they apply padding around buttons, I think as part of their "focus border", and it looks awful,
         //  particularly if you try to set internal spacing to 0.)
-        if (button.getBorder() != null && button.getBorder() instanceof FlatButtonBorder) {
+        if (button.getBorder() instanceof FlatButtonBorder) {
             button.setFocusPainted(false);
             Color borderColor = getColorOptions().getFlatButtonBorderColor();
             if (borderColor == null) {

--- a/src/main/java/ca/corbett/extras/actionpanel/ActionPanel.java
+++ b/src/main/java/ca/corbett/extras/actionpanel/ActionPanel.java
@@ -1823,17 +1823,21 @@ public class ActionPanel extends JPanel {
      * This is here because it's used both for action buttons and also for toolbar buttons.
      */
     void applyButtonPadding(JButton button) {
+        // We will apply whatever buttonPadding has been set:
+        int pad = buttonPadding;
+
         // Special case "flat buttons" because their default border handling is very stupid.
         // (they apply padding around buttons, I think as part of their "focus border", and it looks awful,
         //  particularly if you try to set internal spacing to 0.)
-        // We can also apply the button padding from our ActionPanel, if it is set.
-        int pad = buttonPadding;
         if (button.getBorder() != null && button.getBorder() instanceof FlatButtonBorder) {
             button.setFocusPainted(false);
-            Border lineBorder = BorderFactory.createLineBorder(
-                    LookAndFeelManager.getLafColor("Button.default.startBorderColor", Color.LIGHT_GRAY),
-                    1,
-                    true);
+            Color borderColor = getColorOptions().getFlatButtonBorderColor();
+            if (borderColor == null) {
+                // This is a terrible fallback default, but callers can avoid it being used
+                // by setting an explicit color, or by setting our colors from any ColorTheme.
+                borderColor = LookAndFeelManager.getLafColor("Button.default.startBorderColor", Color.LIGHT_GRAY);
+            }
+            Border lineBorder = BorderFactory.createLineBorder(borderColor, 1, true);
             Border paddingBorder = BorderFactory.createEmptyBorder(pad, pad, pad, pad);
             button.setBorder(BorderFactory.createCompoundBorder(lineBorder, paddingBorder));
         }

--- a/src/main/java/ca/corbett/extras/actionpanel/ColorOptions.java
+++ b/src/main/java/ca/corbett/extras/actionpanel/ColorOptions.java
@@ -35,6 +35,7 @@ public class ColorOptions extends ActionPanelOptions {
     private Color groupHeaderForeground;
     private Color actionButtonBackground;
     private Color toolBarButtonBackground;
+    private Color flatButtonBorderColor;
 
     /**
      * Should only be instantiated by ActionPanel.
@@ -59,6 +60,7 @@ public class ColorOptions extends ActionPanelOptions {
         this.groupHeaderBackground = null; // Use L&F default
         this.actionButtonBackground = null; // Use L&F default
         this.toolBarButtonBackground = null; // Use L&F default
+        this.flatButtonBorderColor = null; // Use L&F default
         fireOptionsChanged();
         return this;
     }
@@ -80,6 +82,7 @@ public class ColorOptions extends ActionPanelOptions {
         this.groupHeaderBackground = theme.getGroupHeaderBackground();
         this.actionButtonBackground = theme.getActionButtonBackground();
         this.toolBarButtonBackground = theme.getToolBarButtonBackground();
+        this.flatButtonBorderColor = theme.getFlatButtonBorderColor();
         fireOptionsChanged();
         return this;
     }
@@ -271,6 +274,32 @@ public class ColorOptions extends ActionPanelOptions {
      */
     public Color getToolBarButtonBackground() {
         return toolBarButtonBackground;
+    }
+
+    /**
+     * Returns the border color for flat buttons. This is used in "flat" themes to provide a
+     * subtle border around buttons. This field is ignored for non-"flat" themes.
+     * If this property is null, the Look and Feel default color will be used for flat button borders.
+     *
+     * @return The border color for flat buttons, or null if L&amp;F default is in use.
+     */
+    public Color getFlatButtonBorderColor() {
+        return flatButtonBorderColor;
+    }
+
+    /**
+     * Sets the border color for flat buttons. This is used in "flat" themes to provide a
+     * subtle border around buttons. This field is ignored for non-"flat" themes.
+     * If you set this property to null, the Look and Feel default color will be used
+     * for flat button borders.
+     *
+     * @param flatButtonBorderColor The border color for flat buttons, or null to use the L&amp;F default.
+     * @return This ColorOptions instance, for method chaining.
+     */
+    public ColorOptions setFlatButtonBorderColor(Color flatButtonBorderColor) {
+        this.flatButtonBorderColor = flatButtonBorderColor;
+        fireOptionsChanged();
+        return this;
     }
 
     /**

--- a/src/main/java/ca/corbett/extras/actionpanel/ColorTheme.java
+++ b/src/main/java/ca/corbett/extras/actionpanel/ColorTheme.java
@@ -38,7 +38,8 @@ public enum ColorTheme {
             new Color(70, 130, 180),  // group header background
             Color.WHITE,                       // group header foreground
             new Color(180, 180, 180), // action button background
-            new Color(160, 160, 160)),// toolbar button background
+            new Color(160, 160, 160), // toolbar button background
+            Color.DARK_GRAY), // flat button border color (used in some themes, ignored in others)
 
     LIGHT("Light",
           new Color(255, 255, 255),  // panel background
@@ -47,7 +48,8 @@ public enum ColorTheme {
           new Color(220, 220, 220),  // group header background
           new Color(0, 0, 0),        // group header foreground
           new Color(200, 200, 200),  // action button background
-          new Color(200, 200, 200)), // toolbar button background
+          new Color(200, 200, 200),  // toolbar button background
+          Color.GRAY), // flat button border color (used in some themes, ignored in others)
 
     DARK("Dark",
          new Color(45, 45, 45),     // panel background
@@ -56,25 +58,28 @@ public enum ColorTheme {
          new Color(70, 70, 70),     // group header background
          new Color(220, 220, 220),  // group header foreground
          new Color(80, 80, 80),     // action button background
-         new Color(80, 80, 80)),    // toolbar button background
+         new Color(80, 80, 80),     // toolbar button background
+         Color.DARK_GRAY), // flat button border color (used in some themes, ignored in others)
 
     ICE("Ice",
-        new Color(45, 45, 45),     // panel background
-        new Color(60, 60, 60),     // action background
-        new Color(220, 220, 220),  // action foreground
-        new Color(70, 130, 180),   // group header background
-        Color.WHITE,                        // group header foreground
-        new Color(80, 80, 80),     // action button background
-        new Color(80, 80, 80)),    // toolbar button background
+        new Color(45, 45, 45),    // panel background
+        new Color(60, 60, 60),    // action background
+        new Color(220, 220, 220), // action foreground
+        new Color(70, 130, 180),  // group header background
+        Color.WHITE,                       // group header foreground
+        new Color(80, 80, 80),    // action button background
+        new Color(80, 80, 80),    // toolbar button background
+        Color.DARK_GRAY), // flat button border color (used in some themes, ignored in others)
 
     MATRIX("Matrix",
-           new Color(0, 48, 0),      // panel background
-           new Color(0, 64, 0),      // action background
-           new Color(0, 255, 0),     // action foreground
-           new Color(0, 128, 0),     // group header background
-           new Color(0, 255, 0),     // group header foreground
-           new Color(0, 96, 0),      // action button background
-           new Color(0, 96, 0)),     // toolbar button background
+           new Color(0, 48, 0),   // panel background
+           new Color(0, 64, 0),   // action background
+           new Color(0, 255, 0),  // action foreground
+           new Color(0, 128, 0),  // group header background
+           new Color(0, 255, 0),  // group header foreground
+           new Color(0, 96, 0),   // action button background
+           new Color(0, 96, 0),   // toolbar button background
+           Color.DARK_GRAY), // flat button border color (used in some themes, ignored in others)
 
     GOT_THE_BLUES("Got the blues",
                   new Color(73, 46, 196),    // panel background
@@ -83,7 +88,8 @@ public enum ColorTheme {
                   new Color(70, 130, 180),   // group header background
                   new Color(255, 255, 255),  // group header foreground
                   new Color(100, 149, 237),  // action button background
-                  new Color(100, 149, 237)), // toolbar button background
+                  new Color(100, 149, 237),  // toolbar button background
+                  Color.GRAY), // flat button border color (used in some themes, ignored in others)
 
     SHADES_OF_GRAY("Shades of gray",
                    new Color(192, 192, 192),  // panel background
@@ -92,7 +98,8 @@ public enum ColorTheme {
                    new Color(128, 128, 128),  // group header background
                    new Color(255, 255, 255),  // group header foreground
                    new Color(140, 140, 140),  // action button background
-                   new Color(140, 140, 140)), // toolbar button background
+                   new Color(140, 140, 140),  // toolbar button background
+                   Color.GRAY), // flat button border color (used in some themes, ignored in others)
 
     HOT_DOG_STAND("Hotdog Stand", // Just for fun!
                   new Color(255, 228, 196),  // panel background
@@ -101,7 +108,8 @@ public enum ColorTheme {
                   new Color(255, 69, 0),     // group header background
                   Color.YELLOW,                       // group header foreground
                   new Color(255, 140, 0),    // action button background
-                  new Color(255, 140, 0));   // toolbar button background
+                  new Color(255, 140, 0),    // toolbar button background
+                  Color.YELLOW); // flat button border color (used in some themes, ignored in others)
 
     private final String label;
     private final Color panelBackground;
@@ -111,10 +119,11 @@ public enum ColorTheme {
     private final Color groupHeaderForeground;
     private final Color actionButtonBackground;
     private final Color toolBarButtonBackground;
+    private final Color flatButtonBorderColor;
 
     ColorTheme(String label, Color panelBackground, Color actionBackground, Color actionForeground,
                Color groupHeaderBackground, Color groupHeaderForeground, Color actionButtonBackground,
-               Color toolBarButtonBackground) {
+               Color toolBarButtonBackground, Color flatButtonBorderColor) {
         this.label = label;
         this.panelBackground = panelBackground;
         this.actionBackground = actionBackground;
@@ -123,6 +132,7 @@ public enum ColorTheme {
         this.groupHeaderForeground = groupHeaderForeground;
         this.actionButtonBackground = actionButtonBackground;
         this.toolBarButtonBackground = toolBarButtonBackground;
+        this.flatButtonBorderColor = flatButtonBorderColor;
     }
 
     @Override
@@ -156,5 +166,9 @@ public enum ColorTheme {
 
     public Color getToolBarButtonBackground() {
         return toolBarButtonBackground;
+    }
+
+    public Color getFlatButtonBorderColor() {
+        return flatButtonBorderColor;
     }
 }

--- a/src/main/java/ca/corbett/extras/demo/panels/ActionPanelDemoPanel.java
+++ b/src/main/java/ca/corbett/extras/demo/panels/ActionPanelDemoPanel.java
@@ -131,6 +131,7 @@ public class ActionPanelDemoPanel extends PanelBuilder implements ExpandListener
     private ColorField actionButtonBackgroundField;
     private ColorField groupHeaderForegroundField;
     private ColorField groupHeaderBackgroundField;
+    private ColorField flatButtonBorderColorField;
     private CheckBoxField toolBarButtonsTransparentField;
     private ColorField toolBarButtonBackgroundField;
     private FontField headerFontField;
@@ -239,6 +240,7 @@ public class ActionPanelDemoPanel extends PanelBuilder implements ExpandListener
         actionButtonBackgroundField.setEnabled(isCustom);
         groupHeaderForegroundField.setEnabled(isCustom);
         groupHeaderBackgroundField.setEnabled(isCustom);
+        flatButtonBorderColorField.setEnabled(isCustom);
         actionPanel.setBackground(isCustom ? actionPanelBackgroundField.getColor() : null);
         actionPanel.getColorOptions().setActionForeground(isCustom ? actionForegroundField.getColor() : null);
         actionPanel.getColorOptions().setActionBackground(isCustom ? actionBackgroundField.getColor() : null);
@@ -246,6 +248,7 @@ public class ActionPanelDemoPanel extends PanelBuilder implements ExpandListener
                    .setActionButtonBackground(isCustom ? actionButtonBackgroundField.getColor() : null);
         actionPanel.getColorOptions().setGroupHeaderForeground(isCustom ? groupHeaderForegroundField.getColor() : null);
         actionPanel.getColorOptions().setGroupHeaderBackground(isCustom ? groupHeaderBackgroundField.getColor() : null);
+        actionPanel.getColorOptions().setFlatButtonBorderColor(isCustom ? flatButtonBorderColorField.getColor() : null);
 
         // ToolBar button customization has an extra layer of enabled/disabled:
         if (isCustom) {
@@ -526,6 +529,12 @@ public class ActionPanelDemoPanel extends PanelBuilder implements ExpandListener
         groupHeaderBackgroundField.getMargins().setLeft(16);
         groupHeaderBackgroundField.addValueChangedListener(f -> colorSourceFieldChanged());
         formPanel.add(groupHeaderBackgroundField);
+
+        flatButtonBorderColorField = new ColorField("Flat button borders:", ColorSelectionType.SOLID);
+        flatButtonBorderColorField.setColor(Color.GRAY);
+        flatButtonBorderColorField.getMargins().setLeft(16);
+        flatButtonBorderColorField.addValueChangedListener(f -> colorSourceFieldChanged());
+        formPanel.add(flatButtonBorderColorField);
 
         toolBarButtonBackgroundField = new ColorField("Toolbar buttons:", ColorSelectionType.SOLID);
         toolBarButtonBackgroundField.setColor(new Color(160, 160, 160)); // arbitrary, but I like it
@@ -1009,6 +1018,7 @@ public class ActionPanelDemoPanel extends PanelBuilder implements ExpandListener
                     groupHeaderForegroundField.setColor(selectedTheme.getGroupHeaderForeground());
                     actionButtonBackgroundField.setColor(selectedTheme.getActionButtonBackground());
                     toolBarButtonBackgroundField.setColor(selectedTheme.getToolBarButtonBackground());
+                    flatButtonBorderColorField.setColor(selectedTheme.getFlatButtonBorderColor());
                 }
                 finally {
                     // Re-enabling auto-rebuild will trigger a single rebuild now that all colors are set:

--- a/src/main/resources/swing-extras/releaseNotes.txt
+++ b/src/main/resources/swing-extras/releaseNotes.txt
@@ -9,6 +9,7 @@ Version 2.9.0 [TODO release date] - Maintenance release
   #430 - AppProperties.peek() now accepts an optional default value
   #425 - Better ImageIO wrapping and error handling in ImageUtil
   #424 - Hit ESC to close the image list panel's preview popup
+  #421 - ActionPanel: fix hard-coded button border color
 
 Version 2.8.0 [2026-03-08] - ActionPanel, TextInputDialog
   #417 - DirTree: add support for file viewing in the tree

--- a/src/test/java/ca/corbett/extras/actionpanel/ColorOptionsTest.java
+++ b/src/test/java/ca/corbett/extras/actionpanel/ColorOptionsTest.java
@@ -38,6 +38,7 @@ class ColorOptionsTest {
         colorOptions.setGroupHeaderBackground(Color.MAGENTA);
         colorOptions.setActionButtonBackground(Color.ORANGE);
         colorOptions.setToolBarButtonBackground(Color.PINK);
+        colorOptions.setFlatButtonBorderColor(Color.YELLOW);
 
         // WHEN we call useSystemDefaults:
         colorOptions.useSystemDefaults();
@@ -50,6 +51,7 @@ class ColorOptionsTest {
         assertNull(colorOptions.getGroupHeaderBackground(), "Group header background should be null after useSystemDefaults");
         assertNull(colorOptions.getActionButtonBackground(), "Action button background should be null after useSystemDefaults");
         assertNull(colorOptions.getToolBarButtonBackground(), "Toolbar button background should be null after useSystemDefaults");
+        assertNull(colorOptions.getFlatButtonBorderColor(), "Flat button border color should be null after useSystemDefaults");
     }
 
     @Test
@@ -63,6 +65,7 @@ class ColorOptionsTest {
         assertNull(colorOptions.getGroupHeaderBackground(), "Group header background should be null by default");
         assertNull(colorOptions.getActionButtonBackground(), "Action button background should be null by default");
         assertNull(colorOptions.getToolBarButtonBackground(), "Toolbar button background should be null by default");
+        assertNull(colorOptions.getFlatButtonBorderColor(), "Flat button border color should be null by default");
     }
 
     @Test
@@ -102,6 +105,8 @@ class ColorOptionsTest {
                 "Action button background should match theme");
         assertEquals(ColorTheme.DEFAULT.getToolBarButtonBackground(), colorOptions.getToolBarButtonBackground(),
                 "Toolbar button background should match theme");
+        assertEquals(ColorTheme.DEFAULT.getFlatButtonBorderColor(), colorOptions.getFlatButtonBorderColor(),
+                "Flat button border color should match theme");
     }
 
     @Test
@@ -277,6 +282,40 @@ class ColorOptionsTest {
     void setToolBarButtonsTransparent_shouldReturnSameInstance_forMethodChaining() {
         assertSame(colorOptions, colorOptions.setToolBarButtonsTransparent(),
                 "setToolBarButtonsTransparent should return the same instance for method chaining");
+    }
+
+    // --- setFlatButtonBorderColor / getFlatButtonBorderColor ---
+
+    @Test
+    void setFlatButtonBorderColor_shouldStoreColor() {
+        colorOptions.setFlatButtonBorderColor(Color.YELLOW);
+        assertEquals(Color.YELLOW, colorOptions.getFlatButtonBorderColor(), "Flat button border color should be YELLOW");
+    }
+
+    @Test
+    void setFlatButtonBorderColor_withNull_shouldClearColor() {
+        colorOptions.setFlatButtonBorderColor(Color.YELLOW);
+        colorOptions.setFlatButtonBorderColor(null);
+        assertNull(colorOptions.getFlatButtonBorderColor(), "Flat button border color should be null after setting null");
+    }
+
+    @Test
+    void setFlatButtonBorderColor_shouldReturnSameInstance_forMethodChaining() {
+        assertSame(colorOptions, colorOptions.setFlatButtonBorderColor(Color.YELLOW),
+                "setFlatButtonBorderColor should return the same instance for method chaining");
+    }
+
+    @Test
+    void setFlatButtonBorderColor_shouldFireOptionsChanged() {
+        // GIVEN a listener is registered:
+        final int[] count = {0};
+        colorOptions.addListener(() -> count[0]++);
+
+        // WHEN we set the flat button border color:
+        colorOptions.setFlatButtonBorderColor(Color.YELLOW);
+
+        // THEN the listener should be notified exactly once:
+        assertEquals(1, count[0], "Options listener should be notified exactly once when flat button border color changes");
     }
 
     // --- getHighlightColor (static) ---


### PR DESCRIPTION
This PR addresses issue #421 by allowing callers to set an explicit border color for flat buttons in certain Look and Feels. The previous behavior of relying on the UIManager's `Button.default.startBorderColor` color is kept as a fallback, if the caller does not explicitly specify a color to use. Updated all built-in color themes to provide a sensible default for this property. Also updated the demo application to expose this new property.