### PR TITLE
Issue #446 - AppProperties: make it easier to use classic props dialog

### DIFF
--- a/src/main/java/ca/corbett/extensions/AppProperties.java
+++ b/src/main/java/ca/corbett/extensions/AppProperties.java
@@ -66,11 +66,22 @@ public abstract class AppProperties<T extends AppExtension> {
 
     private static final Logger logger = Logger.getLogger(AppProperties.class.getName());
 
+    /**
+     * What kind of PropertiesDialog should we generate when the user invokes showPropertiesDialog()?
+     * The default is the new ActionPanel style, introduced in swing-extras 2.8,
+     * but you can specify Classic if you prefer the old style.
+     */
+    public enum DialogType {
+        ActionPanel,
+        Classic
+    }
+
     protected PropertiesManager propsManager;
     protected final ExtensionManager<T> extManager;
 
     private final String appName;
     private final File propsFile;
+    private DialogType dialogType;
 
 
     /**
@@ -85,6 +96,7 @@ public abstract class AppProperties<T extends AppExtension> {
         this.appName = appName;
         this.propsFile = propsFile;
         this.extManager = extManager;
+        this.dialogType = DialogType.ActionPanel;
         reinitialize();
     }
 
@@ -213,6 +225,21 @@ public abstract class AppProperties<T extends AppExtension> {
     }
 
     /**
+     * You can specify which type of PropertiesDialog to generate when the user invokes showPropertiesDialog().
+     * Pass null to return to the default value (ActionPanel).
+     */
+    public void setDialogType(DialogType dialogType) {
+        this.dialogType = dialogType == null ? DialogType.ActionPanel : dialogType;
+    }
+
+    /**
+     * Returns the type of properties dialog that will be generated on the next call to showPropertiesDialog().
+     */
+    public DialogType getDialogType() {
+        return dialogType;
+    }
+
+    /**
      * Generates and shows a PropertiesDialog to allow the user to view or change any
      * of the current properties. If the user okays the dialog, changes are automatically saved.
      * <p>
@@ -241,9 +268,14 @@ public abstract class AppProperties<T extends AppExtension> {
      */
     public boolean showPropertiesDialog(Frame owner, Alignment alignment) {
         reconcileExtensionEnabledStatus();
-        PropertiesDialog dialog = propsManager.generateDialog(owner,
-                                                              appName + " properties",
-                                                                     true);
+        PropertiesDialog dialog = switch (dialogType) {
+            case ActionPanel -> propsManager.generateDialog(owner,
+                                                            appName + " properties",
+                                                            true);
+            case Classic -> propsManager.generateClassicDialog(owner,
+                                                               appName + " properties",
+                                                               true);
+        };
         dialog.setAlignment(alignment);
 
         // Give subclasses a chance to customize this dialog before we show it:

--- a/src/main/java/ca/corbett/extensions/AppProperties.java
+++ b/src/main/java/ca/corbett/extensions/AppProperties.java
@@ -243,6 +243,11 @@ public abstract class AppProperties<T extends AppExtension> {
      * Generates and shows a PropertiesDialog to allow the user to view or change any
      * of the current properties. If the user okays the dialog, changes are automatically saved.
      * <p>
+     *     <b>Note:</b> By default, you will get an ActionPanel-style dialog, which is the
+     *     new option introduced in swing-extras 2.8. If you prefer the "classic" style,
+     *     you can invoke setDialogType(DialogType.Classic) before invoking this method.
+     * </p>
+     * <p>
      *     <b>Note:</b> Descendant classes can customize the PropertiesDialog before
      *     it is shown to the user! See the propertiesDialogCreated() method for details.
      * </p>
@@ -257,6 +262,11 @@ public abstract class AppProperties<T extends AppExtension> {
     /**
      * Generates and shows a PropertiesDialog to allow the user to view or change any
      * of the current properties. If the user okays the dialog, changes are automatically saved.
+     * <p>
+     *     <b>Note:</b> By default, you will get an ActionPanel-style dialog, which is the
+     *     new option introduced in swing-extras 2.8. If you prefer the "classic" style,
+     *     you can invoke setDialogType(DialogType.Classic) before invoking this method.
+     * </p>
      * <p>
      *     <b>Note:</b> Descendant classes can customize the PropertiesDialog before
      *     it is shown to the user! See the propertiesDialogCreated() method for details.

--- a/src/main/resources/swing-extras/releaseNotes.txt
+++ b/src/main/resources/swing-extras/releaseNotes.txt
@@ -2,6 +2,7 @@ swing-extras Release Notes
 Author: Steve Corbett
 
 Version 2.9.0 [TODO release date] - Maintenance release
+  #446 - AppProperties: make it easier to use classic style dialog
   #437 - New convenience class: FallbackExceptionHandler
   #433 - Fix threading issue in UpdateManager's shutdown hooks
   #431 - FileField: allow customization of chooser button


### PR DESCRIPTION
This PR addresses issue #446 by making it easier for client applications to use the "classic"-style properties dialog instead of the newer "action panel" style. The `PropertiesManager` class properly exposes different factory methods for this, but `AppProperties` was never updated to properly expose this functionality.