### PR TITLE
Issue #450 - Absorb the FileWatcher utility class from CryptText

### DIFF
--- a/src/main/java/ca/corbett/extras/io/FileWatcher.java
+++ b/src/main/java/ca/corbett/extras/io/FileWatcher.java
@@ -1,0 +1,285 @@
+package ca.corbett.extras.io;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.ClosedWatchServiceException;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Watches a single file on disk for external changes (modify, delete, or create)
+ * and invokes a caller-supplied callback when a change is detected.
+ * <p>
+ * Uses Java NIO {@link WatchService} to monitor the directory that contains
+ * the watched file.  Only events for the exact target file are forwarded;
+ * changes to other files in the same directory are silently ignored.
+ * </p>
+ * <p>
+ * A debounce mechanism coalesces rapid bursts of events (such as those produced
+ * by editors that truncate-then-rewrite, or by IDEs that perform atomic saves
+ * via a temp-file rename) into a single callback invocation.
+ * </p>
+ * <p>
+ * The watcher runs on dedicated daemon threads and never blocks the Swing EDT.
+ * The supplied callback is invoked directly on the debouncer thread; callers
+ * that need to update Swing components should wrap their callback with
+ * {@link javax.swing.SwingUtilities#invokeLater}.
+ * </p>
+ * <p>
+ * Self-triggered events (events caused by the application saving the file
+ * itself) can be suppressed by calling {@link #ignoreSelfTriggeredChanges()}
+ * immediately <em>before</em> initiating the write operation, so that the
+ * suppression window is guaranteed to be in effect before the WatchService
+ * event arrives.
+ * </p>
+ * <p>
+ * <b>A note about OVERFLOW events:</b> If the native event queue gets too
+ * full, we may receive an OVERFLOW event here, which means "something changed
+ * in the directory, but we don't know exactly what". This code takes a
+ * conservative approach and will treat this as a change to the file under
+ * watch, even though some other file in the same directory may have triggered it.
+ * This means that we may occasionally fire a false positive (callback invoked
+ * when the watched file didn't actually change). The alternative would be
+ * to ignore it, which would risk a false negative (failure to report an actual change).
+ * Neither option is great, but the conservative approach is the safer one.
+ * </p>
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ * @since swing-extras 3.0.0 (absorbed from CryptText)
+ */
+public class FileWatcher {
+
+    private static final Logger log = Logger.getLogger(FileWatcher.class.getName());
+
+    /** Debounce window in milliseconds – events arriving within this window are coalesced. */
+    static final long DEBOUNCE_DELAY_MS = 300;
+
+    /** How long (ms) to suppress events after a self-initiated save. */
+    private static final long SUPPRESS_DURATION_MS = 1000;
+
+    private final File watchedFile;
+    private final Runnable onChange;
+
+    private WatchService watchService;
+    private ScheduledExecutorService debouncer;
+    private final AtomicReference<ScheduledFuture<?>> pendingEvent = new AtomicReference<>();
+    private volatile Thread watchThread;
+    private volatile boolean running;
+    private volatile long suppressUntil = 0;
+
+    /**
+     * Creates a new FileWatcher that will watch the given file.
+     * Call {@link #start()} to begin watching.
+     * <p>
+     * <b>IMPORTANT REMINDER:</b> Your callback will be invoked on a background thread!
+     * If you need to update any UI component, you must marshal back to the Swing EDT using
+     * {@link javax.swing.SwingUtilities#invokeLater}. Failure to do so may result
+     * in subtle and hard-to-debug concurrency issues in your UI. Java Swing is not thread safe!
+     * </p>
+     *
+     * @param file     The file to watch. Must not be null and must have a parent directory.
+     * @param onChange The callback invoked (on the debouncer thread) when a relevant change
+     *                 is detected on disk. Must not be null.
+     * @throws IllegalArgumentException if {@code file} or {@code onChange} is null,
+     *                                  or if {@code file} has no parent directory.
+     */
+    public FileWatcher(File file, Runnable onChange) {
+        if (file == null) {
+            throw new IllegalArgumentException("file cannot be null");
+        }
+        if (file.getParentFile() == null) {
+            throw new IllegalArgumentException("file must have a parent directory");
+        }
+        if (onChange == null) {
+            throw new IllegalArgumentException("onChange cannot be null");
+        }
+        this.watchedFile = file.getAbsoluteFile();
+        this.onChange = onChange;
+    }
+
+    /**
+     * Starts watching the file. Does nothing if the watcher is already running.
+     *
+     * @throws IOException if the underlying {@link WatchService} cannot be created or
+     *                     if the parent directory cannot be registered.
+     */
+    public void start() throws IOException {
+        if (running) {
+            return;
+        }
+        try {
+            watchService = FileSystems.getDefault().newWatchService();
+            debouncer = Executors.newSingleThreadScheduledExecutor(r -> {
+                Thread t = new Thread(r, "FileWatcher-debouncer-" + watchedFile.getName());
+                t.setDaemon(true);
+                return t;
+            });
+            Path dir = watchedFile.getParentFile().toPath();
+            dir.register(watchService,
+                         StandardWatchEventKinds.ENTRY_MODIFY,
+                         StandardWatchEventKinds.ENTRY_DELETE,
+                         StandardWatchEventKinds.ENTRY_CREATE);
+            running = true;
+            watchThread = new Thread(this::watchLoop, "FileWatcher-" + watchedFile.getName());
+            watchThread.setDaemon(true);
+            watchThread.start();
+            log.fine("FileWatcher started for: " + watchedFile.getAbsolutePath());
+        }
+        catch (IOException e) {
+            stop(); // clean up any partially-initialized resources
+            throw e;
+        }
+    }
+
+    /**
+     * Returns true if this watcher is currently active.
+     */
+    public boolean isRunning() {
+        return running;
+    }
+
+    /**
+     * Stops watching the file and releases all associated resources.
+     * Safe to call even if the watcher was never started.
+     */
+    public void stop() {
+        running = false;
+        ScheduledFuture<?> pending = pendingEvent.getAndSet(null);
+        if (pending != null) {
+            pending.cancel(false);
+        }
+        if (watchService != null) {
+            try {
+                watchService.close();
+            }
+            catch (IOException e) {
+                log.log(Level.WARNING, "Error closing WatchService for: " + watchedFile.getAbsolutePath(), e);
+            }
+        }
+        if (debouncer != null) {
+            debouncer.shutdownNow();
+        }
+        if (watchThread != null) {
+            watchThread.interrupt();
+        }
+        log.fine("FileWatcher stopped for: " + watchedFile.getAbsolutePath());
+    }
+
+    /**
+     * Suppresses the next change event(s) for a short window after a self-initiated write.
+     * Call this immediately <em>before</em> initiating the write operation, so that the
+     * suppression window is guaranteed to be in effect before the WatchService event arrives.
+     * Any already-pending debounced event is also cancelled.
+     */
+    public void ignoreSelfTriggeredChanges() {
+        suppressUntil = System.currentTimeMillis() + SUPPRESS_DURATION_MS;
+        ScheduledFuture<?> pending = pendingEvent.getAndSet(null);
+        if (pending != null) {
+            pending.cancel(false);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal implementation
+    // -------------------------------------------------------------------------
+
+    private void watchLoop() {
+        try {
+            while (running) {
+                WatchKey key;
+                try {
+                    key = watchService.take();
+                }
+                catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+                catch (ClosedWatchServiceException e) {
+                    break;
+                }
+
+                for (WatchEvent<?> event : key.pollEvents()) {
+                    WatchEvent.Kind<?> kind = event.kind();
+                    if (kind == StandardWatchEventKinds.OVERFLOW) {
+                        // *something* just changed in the directory under watch,
+                        // but unfortunately we don't know what. It might have been
+                        // some other file, or it might have been the one we're watching.
+                        // Our options are:
+                        //   1) ignore it, and possibly miss a relevant change
+                        //   2) treat it as a change to our file, even though it might not have been.
+                        // Neither option is great, but the safest option is 2,
+                        // so we will schedule a callback just in case.
+                        scheduleDebounced();
+                        continue; // OVERFLOW events have no context, so let's avoid an NPE in the code below.
+                    }
+
+                    @SuppressWarnings("unchecked")
+                    WatchEvent<Path> pathEvent = (WatchEvent<Path>)event;
+                    Path changedPath = ((Path)key.watchable()).resolve(pathEvent.context());
+
+                    if (changedPath.toAbsolutePath().equals(watchedFile.toPath().toAbsolutePath())) {
+                        scheduleDebounced();
+                    }
+                }
+
+                if (!key.reset()) {
+                    break;
+                }
+            }
+        }
+        finally {
+            cleanupAfterWatchLoopExit();
+        }
+    }
+
+    private void cleanupAfterWatchLoopExit() {
+        running = false;
+
+        ScheduledFuture<?> pending = pendingEvent.getAndSet(null);
+        if (pending != null) {
+            pending.cancel(false);
+        }
+
+        debouncer.shutdownNow();
+
+        try {
+            watchService.close();
+        }
+        catch (IOException | ClosedWatchServiceException ignored) {
+            // Already closed or no further cleanup possible.
+        }
+    }
+
+    private void scheduleDebounced() {
+        if (!running) {
+            return;
+        }
+        ScheduledFuture<?> old = pendingEvent.getAndSet(null);
+        if (old != null) {
+            old.cancel(false);
+        }
+        try {
+            ScheduledFuture<?> next = debouncer.schedule(() -> {
+                if (running && System.currentTimeMillis() >= suppressUntil) {
+                    onChange.run();
+                }
+            }, DEBOUNCE_DELAY_MS, TimeUnit.MILLISECONDS);
+            pendingEvent.set(next);
+        }
+        catch (RejectedExecutionException ignored) {
+            // Executor was shut down concurrently; nothing to schedule.
+        }
+    }
+}

--- a/src/main/java/ca/corbett/extras/io/FileWatcher.java
+++ b/src/main/java/ca/corbett/extras/io/FileWatcher.java
@@ -275,8 +275,10 @@ public class FileWatcher {
             old.cancel(false);
         }
         try {
+            long remainingSuppressMillis = Math.max(0L, suppressUntil - System.currentTimeMillis());
+            long suppressUntilNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(remainingSuppressMillis);
             ScheduledFuture<?> next = debouncer.schedule(() -> {
-                if (running && System.currentTimeMillis() >= suppressUntil) {
+                if (running && System.nanoTime() >= suppressUntilNanos) {
                     onChange.run();
                 }
             }, DEBOUNCE_DELAY_MS, TimeUnit.MILLISECONDS);

--- a/src/main/java/ca/corbett/extras/io/FileWatcher.java
+++ b/src/main/java/ca/corbett/extras/io/FileWatcher.java
@@ -221,6 +221,10 @@ public class FileWatcher {
                         //   2) treat it as a change to our file, even though it might not have been.
                         // Neither option is great, but the safest option is 2,
                         // so we will schedule a callback just in case.
+                        Logger.getLogger(FileWatcher.class.getName()).log(Level.WARNING,
+                                "WatchService overflow for watched file {0} in directory {1}; events may have been lost. "
+                                        + "Scheduling a callback conservatively.",
+                                new Object[]{watchedFile.getAbsolutePath(), key.watchable()});
                         scheduleDebounced();
                         continue; // OVERFLOW events have no context, so let's avoid an NPE in the code below.
                     }

--- a/src/main/resources/swing-extras/releaseNotes.txt
+++ b/src/main/resources/swing-extras/releaseNotes.txt
@@ -5,6 +5,7 @@ Version 3.0.0 [TODO - release date] - Major refactoring
   #456 - Upgrade all dependency versions to latest
   #455 - Drop support for JTattoo
   #453 - Fix bug in ActionPanel demo panel
+  #450 - Absorb the FileWatcher class from CryptText
   #443 - Upgrade to Java 25
 
 Version 2.9.0 [2026-04-13] - Maintenance release

--- a/src/test/java/ca/corbett/extras/io/FileWatcherTest.java
+++ b/src/test/java/ca/corbett/extras/io/FileWatcherTest.java
@@ -1,0 +1,213 @@
+package ca.corbett.extras.io;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FileWatcherTest {
+
+    @TempDir
+    File tempDir;
+
+    private FileWatcher watcher;
+
+    @AfterEach
+    void tearDown() {
+        if (watcher != null) {
+            watcher.stop();
+        }
+    }
+
+    // ---- constructor validation ----
+
+    @Test
+    void constructor_withNullFile_shouldThrowException() {
+        assertThrows(IllegalArgumentException.class,
+                     () -> new FileWatcher(null, () -> {
+                     }));
+    }
+
+    @Test
+    void constructor_withNullCallback_shouldThrowException() throws IOException {
+        File file = File.createTempFile("fwt", ".txt", tempDir);
+        assertThrows(IllegalArgumentException.class,
+                     () -> new FileWatcher(file, null));
+    }
+
+    @Test
+    void constructor_withFileHavingNoParent_shouldThrowException() {
+        // A File with no parent path component has getParentFile() == null:
+        File noParent = new File("orphan.txt");
+        assertThrows(IllegalArgumentException.class,
+                     () -> new FileWatcher(noParent, () -> {
+                     }));
+    }
+
+    // ---- change detection ----
+
+    @Test
+    void start_thenModifyWatchedFile_shouldInvokeCallback() throws Exception {
+        // GIVEN a watched file and a latch to wait for the callback:
+        File file = File.createTempFile("fwt", ".txt", tempDir);
+        CountDownLatch latch = new CountDownLatch(1);
+
+        watcher = new FileWatcher(file, latch::countDown);
+        watcher.start();
+
+        // WHEN the watched file is modified:
+        Files.writeString(file.toPath(), "hello world");
+
+        // THEN the callback should be invoked within a reasonable timeout:
+        boolean called = latch.await(3, TimeUnit.SECONDS);
+        assertTrue(called, "Callback should have been invoked after file modification");
+    }
+
+    @Test
+    void start_thenDeleteWatchedFile_shouldInvokeCallback() throws Exception {
+        // GIVEN a watched file:
+        File file = File.createTempFile("fwt", ".txt", tempDir);
+        CountDownLatch latch = new CountDownLatch(1);
+
+        watcher = new FileWatcher(file, latch::countDown);
+        watcher.start();
+
+        // WHEN the watched file is deleted:
+        Files.delete(file.toPath());
+
+        // THEN the callback should be invoked:
+        boolean called = latch.await(3, TimeUnit.SECONDS);
+        assertTrue(called, "Callback should have been invoked after file deletion");
+    }
+
+    @Test
+    void start_thenModifyUnrelatedFile_shouldNotInvokeCallback() throws Exception {
+        // GIVEN a watched file and an unrelated file in the same directory:
+        File watchedFile = File.createTempFile("fwt-watched", ".txt", tempDir);
+        File otherFile = File.createTempFile("fwt-other", ".txt", tempDir);
+        AtomicInteger callCount = new AtomicInteger(0);
+
+        watcher = new FileWatcher(watchedFile, callCount::incrementAndGet);
+        watcher.start();
+
+        // WHEN only the unrelated file is modified:
+        Files.writeString(otherFile.toPath(), "some change");
+
+        // THEN the callback should NOT be invoked (wait beyond the debounce window):
+        Thread.sleep(FileWatcher.DEBOUNCE_DELAY_MS + 500);
+        assertEquals(0, callCount.get(), "Callback should not fire for unrelated file changes");
+    }
+
+    @Test
+    void start_withRapidMultipleModifications_shouldCoalesceIntoSingleCallback() throws Exception {
+        // GIVEN a watched file:
+        File file = File.createTempFile("fwt", ".txt", tempDir);
+        AtomicInteger callCount = new AtomicInteger(0);
+        CountDownLatch latch = new CountDownLatch(1);
+
+        watcher = new FileWatcher(file, () -> {
+            callCount.incrementAndGet();
+            latch.countDown();
+        });
+        watcher.start();
+
+        // WHEN the file is modified multiple times in rapid succession (within the debounce window):
+        for (int i = 0; i < 5; i++) {
+            Files.writeString(file.toPath(), "content " + i);
+            Thread.sleep(30); // faster than DEBOUNCE_DELAY_MS
+        }
+
+        // THEN the callback should be invoked only once (debounced):
+        boolean called = latch.await(3, TimeUnit.SECONDS);
+        assertTrue(called, "Callback should have been invoked at least once");
+        assertEquals(1, callCount.get(), "Rapid modifications should be coalesced into a single callback");
+    }
+
+    // ---- suppression ----
+
+    @Test
+    void ignoreSelfTriggeredChanges_shouldSuppressSubsequentCallback() throws Exception {
+        // GIVEN a watched file:
+        File file = File.createTempFile("fwt", ".txt", tempDir);
+        AtomicInteger callCount = new AtomicInteger(0);
+
+        watcher = new FileWatcher(file, callCount::incrementAndGet);
+        watcher.start();
+
+        // WHEN we suppress self-triggered changes and then modify the file:
+        watcher.ignoreSelfTriggeredChanges();
+        Files.writeString(file.toPath(), "self-written content");
+
+        // THEN the callback should NOT be invoked within the suppression window:
+        Thread.sleep(FileWatcher.DEBOUNCE_DELAY_MS + 500);
+        assertEquals(0, callCount.get(), "Self-triggered change should be suppressed");
+    }
+
+    @Test
+    void ignoreSelfTriggeredChanges_afterSuppressionWindowExpires_shouldAllowNextCallback() throws Exception {
+        // GIVEN a watched file:
+        File file = File.createTempFile("fwt", ".txt", tempDir);
+        AtomicInteger callCount = new AtomicInteger(0);
+        CountDownLatch latch = new CountDownLatch(1);
+
+        // Use a FileWatcher with a very short suppression window for this test:
+        // (We cannot easily override the constant, so we rely on the 1-second default
+        //  and wait for it to expire before making a new change.)
+        watcher = new FileWatcher(file, () -> {
+            callCount.incrementAndGet();
+            latch.countDown();
+        });
+        watcher.start();
+
+        // WHEN we suppress, wait past the window, then modify:
+        watcher.ignoreSelfTriggeredChanges();
+        Thread.sleep(1200); // wait for the 1-second suppression window to expire
+        Files.writeString(file.toPath(), "external content");
+
+        // THEN the callback SHOULD be invoked now that the window has expired:
+        boolean called = latch.await(3, TimeUnit.SECONDS);
+        assertTrue(called, "Callback should fire after suppression window has expired");
+        assertEquals(1, callCount.get());
+    }
+
+    // ---- stop ----
+
+    @Test
+    void stop_shouldPreventFurtherCallbacks() throws Exception {
+        // GIVEN a running watcher:
+        File file = File.createTempFile("fwt", ".txt", tempDir);
+        AtomicInteger callCount = new AtomicInteger(0);
+
+        watcher = new FileWatcher(file, callCount::incrementAndGet);
+        watcher.start();
+
+        // WHEN the watcher is stopped and then the file is modified:
+        watcher.stop();
+        Files.writeString(file.toPath(), "post-stop content");
+
+        // THEN no callback should be fired:
+        Thread.sleep(FileWatcher.DEBOUNCE_DELAY_MS + 500);
+        assertEquals(0, callCount.get(), "Callback should not fire after watcher is stopped");
+    }
+
+    @Test
+    void stop_calledBeforeStart_shouldNotThrow() {
+        // GIVEN a watcher that was never started:
+        File file = new File(tempDir, "not-created.txt");
+        watcher = new FileWatcher(file, () -> {
+        });
+
+        // WHEN stop() is called, THEN no exception should be thrown:
+        watcher.stop();
+    }
+}


### PR DESCRIPTION
This PR addresses issue #450 by absorbing the `FileWatcher` class from a client application, so that it can be re-used by other client applications. The code was imported more or less as-is, with the addition of more conservative handling of `OVERFLOW` events. Previously, this was ignored. This version of the class will treat them as a change to the file under watch, even though it can't be verified. 

Also, improved the javadocs to add explicit warnings about event callbacks being issued on the background thread, and not on the Swing EDT. Client applications have to be disciplined about marshaling UI updates to the correct thread.
