### PR TITLE
Issue #451 - fix windows-specific bug in FileProperty and DirectoryProperty

### DIFF
--- a/src/main/java/ca/corbett/extras/properties/DirectoryProperty.java
+++ b/src/main/java/ca/corbett/extras/properties/DirectoryProperty.java
@@ -56,7 +56,7 @@ public class DirectoryProperty extends AbstractProperty {
 
     @Override
     public void saveToProps(Properties props) {
-        props.setString(fullyQualifiedName + ".dir", (dir == null) ? "" : dir.getAbsolutePath());
+        props.setPlatformSafeFilePath(fullyQualifiedName + ".dir", (dir == null) ? "" : dir.getAbsolutePath());
         props.setInteger(fullyQualifiedName + ".cols", columns);
     }
 

--- a/src/main/java/ca/corbett/extras/properties/FileBasedProperties.java
+++ b/src/main/java/ca/corbett/extras/properties/FileBasedProperties.java
@@ -262,6 +262,14 @@ public final class FileBasedProperties extends Properties {
     }
 
     @Override
+    public void setPlatformSafeFilePath(String name, String path) {
+        super.setPlatformSafeFilePath(name, path);
+        if (eagerSave) {
+            saveWithoutException();
+        }
+    }
+
+    @Override
     public void setFont(String name, Font font) {
         super.setFont(name, font);
         if (eagerSave) {

--- a/src/main/java/ca/corbett/extras/properties/FileProperty.java
+++ b/src/main/java/ca/corbett/extras/properties/FileProperty.java
@@ -95,7 +95,7 @@ public class FileProperty extends AbstractProperty {
     @Override
     public void saveToProps(Properties props) {
         props.setBoolean(fullyQualifiedName + ".allowBlank", allowBlank);
-        props.setString(fullyQualifiedName + ".file", (file == null) ? "" : file.getAbsolutePath());
+        props.setPlatformSafeFilePath(fullyQualifiedName + ".file", (file == null) ? "" : file.getAbsolutePath());
         props.setInteger(fullyQualifiedName + ".cols", columns);
         props.setString(fullyQualifiedName + ".selectionType", selectionType.name());
     }

--- a/src/main/java/ca/corbett/extras/properties/Properties.java
+++ b/src/main/java/ca/corbett/extras/properties/Properties.java
@@ -78,6 +78,39 @@ public class Properties {
     }
 
     /**
+     * Accepts the given String as a file path, and will ensure it is stored in a platform-safe way.
+     * Specifically, this involves changing single backslash path separators on a Windows-based system
+     * into double backslashes, so that they are escaped properly when read back out.
+     * On non-Windows systems, the path is stored as-is.
+     *
+     * @param name The property name.
+     * @param path The file path to store.
+     */
+    public void setPlatformSafeFilePath(String name, String path) {
+        if (path == null) {
+            logger.log(Level.WARNING, "Ignoring null String value for property \"{0}\"", name);
+            return;
+        }
+
+        // Special-case blank values to avoid unnecessary overhead:
+        if (path.isBlank()) {
+            props.setProperty(name, path);
+            return;
+        }
+
+        boolean isWindows = System.getProperty("os.name").toLowerCase().contains("win");
+        if (isWindows) {
+            // On Windows, we need to escape backslashes in file paths by doubling them up:
+            String escapedPath = path.replace("\\", "\\\\");
+            props.setProperty(name, escapedPath);
+        }
+        else {
+            // On non-Windows systems, we can store the path as-is:
+            props.setProperty(name, path);
+        }
+    }
+
+    /**
      * Retrieves the String value of the named property, if any.
      * If the stored value is explicitly blank, then a blank string is returned.
      * If you wish to treat blank strings the same as null/missing values,

--- a/src/main/resources/swing-extras/releaseNotes.txt
+++ b/src/main/resources/swing-extras/releaseNotes.txt
@@ -5,6 +5,7 @@ Version 3.0.0 [TODO - release date] - Major refactoring
   #456 - Upgrade all dependency versions to latest
   #455 - Drop support for JTattoo
   #453 - Fix bug in ActionPanel demo panel
+  #451 - Fix Windows-specific bug in File/DirectoryProperty
   #450 - Absorb the FileWatcher class from CryptText
   #443 - Upgrade to Java 25
 

--- a/src/test/java/ca/corbett/extras/properties/FileBasedPropertiesTest.java
+++ b/src/test/java/ca/corbett/extras/properties/FileBasedPropertiesTest.java
@@ -71,4 +71,37 @@ public class FileBasedPropertiesTest {
         assertEquals(0, props.getColor("invisibleGrey", null).getAlpha());
         assertEquals(255, props.getColor("noAlphaSpecified", null).getAlpha());
     }
+
+    @Test
+    public void roundTripSaveRestore_withWindowsPath_shouldRestoreCorrectly() throws IOException {
+        String osName = System.getProperty("os.name");
+        try {
+            // GIVEN that we are running on a Windows-based system (or pretending to be, anyway):
+            System.setProperty("os.name", "Windows ME super real edition, totally not a lie");
+
+            // and GIVEN a save attempt with some Windows-style paths:
+            File file = File.createTempFile("test", ".test");
+            file.deleteOnExit();
+            FileBasedProperties props = new FileBasedProperties(file);
+            final String path1 = "C:\\Users\\Test\\file.txt";
+            final String path2 = "D:\\Data\\my file.txt";
+            props.setPlatformSafeFilePath("winPath1", path1);
+            props.setPlatformSafeFilePath("winPath2", path2);
+            props.save();
+
+            // WHEN we load those properties back:
+            FileBasedProperties props2 = new FileBasedProperties(file);
+            props2.load();
+            String actualPath1 = props2.getString("winPath1", "");
+            String actualPath2 = props2.getString("winPath2", "");
+
+            // THEN they should have survived the trip:
+            assertEquals(path1, actualPath1);
+            assertEquals(path2, actualPath2);
+        }
+        finally {
+            // Make sure we clean up after ourselves:
+            System.setProperty("os.name", osName);
+        }
+    }
 }


### PR DESCRIPTION
This PR addresses issue #451 by fixing a Windows-specific bug in `FileProperty` and `DirectoryProperty`, where file paths were being written out without escaping the backslash character. This would result in corrupted file paths being read in on the next properties load. Added red/green unit test to prove the fix.