### PR TITLE
Issue #452 - FlatLaf Windows resize bug

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,7 +16,7 @@
 - **Java**: 17 (required - do not change)
 - **Maven**: 3.9.11+
 - **Testing**: JUnit 5.12.1, Mockito 5.14.2
-- **UI Libraries**: FlatLaf 3.6, JTattoo 1.6.13
+- **UI Libraries**: FlatLaf 3.7.1
 - **Serialization**: Gson 2.12.1
 
 ## Build and Test Instructions

--- a/src/main/java/ca/corbett/extras/LookAndFeelManager.java
+++ b/src/main/java/ca/corbett/extras/LookAndFeelManager.java
@@ -88,7 +88,7 @@ public class LookAndFeelManager {
      * </p>
      */
     public static void installExtraLafs() {
-        // Only do this one:
+        // Only do this once:
         if (installationComplete) {
             return;
         }

--- a/src/main/java/ca/corbett/extras/LookAndFeelManager.java
+++ b/src/main/java/ca/corbett/extras/LookAndFeelManager.java
@@ -66,6 +66,13 @@ import java.util.logging.Logger;
 /**
  * This is a simple wrapper class to manage the various look and feels that
  * spring-extras supports.
+ * <p>
+ * <b>Note for Windows users:</b> there's a weird bug in FlatLaf that will prevent your JFrames
+ * from being resizable. This class automatically provides a workaround of disabling FlatLaf's window decorations
+ * if running on a Windows machine, but this may have cosmetic side effects. You can prevent this workaround
+ * from triggering by explicitly setting "flatlaf.useWindowDecorations" to "true" when starting your application.
+ * The workaround only triggers on Windows-based systems.
+ * </p>
  *
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
  * @since 2025-04-22
@@ -99,7 +106,10 @@ public class LookAndFeelManager {
         if (osName != null && osName.toLowerCase(Locale.ROOT).contains("win")) {
             // Something about FlatLaf's window decorations disables the click-and-drag-to-resize
             // functionality on Windows systems (at least with OpenJDK 21 it does). This workaround fixes it.
-            System.setProperty("flatlaf.useWindowDecorations", "false");
+            // Callers can prevent the workaround by explicitly setting "flatlaf.useWindowDecorations" to "true".
+            if (System.getProperty("flatlaf.useWindowDecorations") == null) {
+                System.setProperty("flatlaf.useWindowDecorations", "false");
+            }
         }
 
         // The "core" themes provided by FlatLaf:

--- a/src/main/java/ca/corbett/extras/LookAndFeelManager.java
+++ b/src/main/java/ca/corbett/extras/LookAndFeelManager.java
@@ -58,6 +58,7 @@ import java.awt.Color;
 import java.awt.Window;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -73,21 +74,33 @@ public class LookAndFeelManager {
     private static final Logger logger = Logger.getLogger(LookAndFeelManager.class.getName());
 
     private static final List<ChangeListener> changeListeners = new ArrayList<>();
+    private static boolean installationComplete = false;
 
     /**
      * Can be invoked (ideally at application startup before any GUI elements are shown)
      * to install all the "extra" LaFs that swing-extras supports, namely from the
-     * FlatLaf package and also JTattoo. With the JTattoo themes we have to tweak
-     * them a bit to avoid some wonky default behaviour with menus (it wants to show
-     * a sideways logo in every menu for some reason - we can disable it).
+     * FlatLaf package.
      * <p>
      *     Implementation note: this code is in a public static method instead of
      *     in a static initializer block because your app might not care about
      *     LaF, in which case you can just ignore this method and avoid whatever
-     *     memory penalty in would otherwise incur.
+     *     memory penalty it would otherwise incur.
      * </p>
      */
     public static void installExtraLafs() {
+        // Only do this one:
+        if (installationComplete) {
+            return;
+        }
+
+        // Avoid the dreaded "you can't resize your window" bug on Windows-based systems.
+        String osName = System.getProperty("os.name");
+        if (osName != null && osName.toLowerCase(Locale.ROOT).contains("win")) {
+            // Something about FlatLaf's window decorations disables the click-and-drag-to-resize
+            // functionality on Windows systems (at least with OpenJDK 21 it does). This workaround fixes it.
+            System.setProperty("flatlaf.useWindowDecorations", "false");
+        }
+
         // The "core" themes provided by FlatLaf:
         FlatLightLaf.installLafInfo();
         FlatDarkLaf.installLafInfo();
@@ -140,6 +153,8 @@ public class LookAndFeelManager {
         FlatMTNightOwlIJTheme.installLafInfo();
         FlatMTSolarizedDarkIJTheme.installLafInfo();
         FlatMTSolarizedLightIJTheme.installLafInfo();
+
+        installationComplete = true;
     }
 
     /**
@@ -158,6 +173,11 @@ public class LookAndFeelManager {
      * @param className The name of the LaF class in question.
      */
     public static void switchLaf(String className) {
+        // If we have not yet installed the extra stuff, do it now:
+        if (!installationComplete) {
+            installExtraLafs();
+        }
+
         try {
             UIManager.setLookAndFeel(className);
             for (Window w : Window.getWindows()) {

--- a/src/main/java/ca/corbett/extras/LookAndFeelManager.java
+++ b/src/main/java/ca/corbett/extras/LookAndFeelManager.java
@@ -59,6 +59,7 @@ import java.awt.Window;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -74,7 +75,7 @@ public class LookAndFeelManager {
     private static final Logger logger = Logger.getLogger(LookAndFeelManager.class.getName());
 
     private static final List<ChangeListener> changeListeners = new ArrayList<>();
-    private static boolean installationComplete = false;
+    private final static AtomicBoolean installationComplete = new AtomicBoolean(false);
 
     /**
      * Can be invoked (ideally at application startup before any GUI elements are shown)
@@ -89,7 +90,7 @@ public class LookAndFeelManager {
      */
     public static void installExtraLafs() {
         // Only do this once:
-        if (installationComplete) {
+        if (installationComplete.get()) {
             return;
         }
 
@@ -154,7 +155,7 @@ public class LookAndFeelManager {
         FlatMTSolarizedDarkIJTheme.installLafInfo();
         FlatMTSolarizedLightIJTheme.installLafInfo();
 
-        installationComplete = true;
+        installationComplete.set(true);
     }
 
     /**
@@ -174,7 +175,7 @@ public class LookAndFeelManager {
      */
     public static void switchLaf(String className) {
         // If we have not yet installed the extra stuff, do it now:
-        if (!installationComplete) {
+        if (!installationComplete.get()) {
             installExtraLafs();
         }
 

--- a/src/main/resources/swing-extras/releaseNotes.txt
+++ b/src/main/resources/swing-extras/releaseNotes.txt
@@ -5,6 +5,7 @@ Version 3.0.0 [TODO - release date] - Major refactoring
   #456 - Upgrade all dependency versions to latest
   #455 - Drop support for JTattoo
   #453 - Fix bug in ActionPanel demo panel
+  #452 - Fix FlatLaf Look and Feel bug on Windows systems
   #451 - Fix Windows-specific bug in File/DirectoryProperty
   #450 - Absorb the FileWatcher class from CryptText
   #443 - Upgrade to Java 25


### PR DESCRIPTION
This PR addresses issue #452 by fixing a Windows-specific bug related to the FlatLaf look and feels. The fix allows JFrame instances to be properly resized.

Unrelated to that fix, this PR also cleans up `LookAndFeelManager` a bit:

- remove lingering references to JTattoo, which has been dropped from swing-extras
- make `installExtraLafs` idempotent
- ensure `installExtraLafs` has been invoked before switching look and feel
