### PR TITLE
Issue #449 - make FileSystemUtil less wonky

### DIFF
--- a/src/main/java/ca/corbett/extras/io/FileSystemUtil.java
+++ b/src/main/java/ca/corbett/extras/io/FileSystemUtil.java
@@ -9,7 +9,6 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Enumeration;
 import java.util.HashSet;
@@ -131,11 +130,6 @@ public class FileSystemUtil {
             return new ArrayList<>();
         }
 
-        // If the extension list is empty, we match everything. No extension list means "no filter".
-        if (extSet.isEmpty()) {
-            return Arrays.asList(children);
-        }
-
         List<File> fileList = new ArrayList<>();
 
         for (File child : children) {
@@ -152,6 +146,14 @@ public class FileSystemUtil {
                         fileMatched = true;
                         break; // Found match, no need to check other extensions
                     }
+                }
+
+                // Special handling for empty extension list: if extSet is empty, we consider it a match for all files:
+                if (extSet.isEmpty()) {
+                    // If it's a regular, non-inverted search, empty list means "match everything".
+                    // If it's an inverted search, empty list means "exclude nothing".
+                    // "fileMatched" will be interpreted correctly in either case by the logic below.
+                    fileMatched = !invertSearch;
                 }
 
                 // If the file matched an extension and our search is not inverted, it's a hit:

--- a/src/main/java/ca/corbett/extras/io/FileSystemUtil.java
+++ b/src/main/java/ca/corbett/extras/io/FileSystemUtil.java
@@ -13,6 +13,7 @@ import java.util.Comparator;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
@@ -75,7 +76,8 @@ public class FileSystemUtil {
     /**
      * Scans the given directory (and optionally all of its subdirectories recursively) looking for
      * files with the given extension. Files matching the extension will be returned, while all
-     * other files will be excluded.
+     * other files will be excluded. If the provided extension is null or blank, ALL files will
+     * be returned, regardless of extension. The returned list is sorted by full path name.
      *
      * @param rootDir   The root directory for the search. Must exist and be readable.
      * @param recursive Indicates whether to search sub directories also or not.
@@ -88,7 +90,9 @@ public class FileSystemUtil {
                                        final String extension,
                                        final FileSearchListener listener) {
         List<String> extensions = new ArrayList<>();
-        extensions.add(extension);
+        if (extension != null && !extension.isBlank()) {
+            extensions.add(extension);
+        }
         return findFiles(rootDir, recursive, extensions, listener);
     }
 
@@ -96,6 +100,7 @@ public class FileSystemUtil {
      * Scans the given directory (and optionally all of its subdirectories recursively) looking for
      * files of one of the types specified in the given fileType list. Files matching any of the
      * extensions in that list will be returned, while all other files will be excluded.
+     * If the given list of extensions is null or empty, ALL files will be returned, regardless of extension.
      *
      * @param rootDir    The root directory for the search. Must exist and be readable.
      * @param recursive  Indicates whether to search sub directories also or not.
@@ -105,15 +110,9 @@ public class FileSystemUtil {
      */
     public static List<File> findFiles(final File rootDir,
                                        final boolean recursive,
-                                       final List<String> extensions,
+                                       List<String> extensions,
                                        final FileSearchListener listener) {
-        // Pre-process extensions once (lowercase + add dots)
-        Set<String> extSet = new HashSet<>();
-        for (String ext : extensions) {
-            extSet.add("." + ext.toLowerCase());
-        }
-
-        List<File> result = findFilesRecurse(rootDir, recursive, extSet, listener, false);
+        List<File> result = findFilesRecurse(rootDir, recursive, normalizeExtensionsToSet(extensions), listener, false);
         sortFiles(result); // Sort only once at the end
         return result;
     }
@@ -141,7 +140,7 @@ public class FileSystemUtil {
                 String filename = child.getName().toLowerCase();
 
                 // if any extensions match, it's a hit:
-                boolean fileMatched = false;
+                boolean fileMatched = extSet.isEmpty(); // empty list == automatic match
                 for (String ext : extSet) {
                     if (filename.endsWith(ext)) {
                         fileMatched = true;
@@ -231,13 +230,7 @@ public class FileSystemUtil {
                                                 final boolean recursive,
                                                 final List<String> extensions,
                                                 final FileSearchListener listener) {
-        // Pre-process extensions once (lowercase + add dots)
-        Set<String> extSet = new HashSet<>();
-        for (String ext : extensions) {
-            extSet.add("." + ext.toLowerCase());
-        }
-
-        List<File> result = findFilesRecurse(rootDir, recursive, extSet, listener, true);
+        List<File> result = findFilesRecurse(rootDir, recursive, normalizeExtensionsToSet(extensions), listener, true);
         sortFiles(result); // Sort only once at the end
         return result;
     }
@@ -267,7 +260,7 @@ public class FileSystemUtil {
     public static List<File> findFiles(final File rootDir,
                                        final boolean recursive,
                                        final FileSearchListener listener) {
-        return findFilesExcluding(rootDir, recursive, new ArrayList<>(), listener);
+        return findFiles(rootDir, recursive, new ArrayList<>(), listener);
     }
 
     /**
@@ -700,5 +693,37 @@ public class FileSystemUtil {
 
         // Extremely unlikely, but just in case we hit the limit:
         return new File(destinationDir, nameWithoutExt + System.currentTimeMillis() + ext);
+    }
+
+    /**
+     * Given a list of file extensions, which may be null or empty (and the list itself may also be
+     * null or empty), return a Set of normalized extensions. Normalization includes trimming whitespace, converting to
+     * lowercase, and ensuring that each extension starts with a dot.
+     * If the input list is null or empty, an empty set will be returned.
+     * Any entry in the list that is null or blank will be ignored.
+     * The returned set may be empty even in cases where the input list is not empty,
+     * if all entries in the list are null or blank.
+     */
+    static Set<String> normalizeExtensionsToSet(List<String> extensions) {
+        if (extensions == null) {
+            extensions = new ArrayList<>();
+        }
+
+        // Pre-process extensions once (lowercase + trim + add dots if needed)
+        Set<String> extSet = new HashSet<>();
+        for (String ext : extensions) {
+            if (ext == null || ext.isBlank()) {
+                continue;
+            }
+            ext = ext.trim().toLowerCase(Locale.ROOT);
+            if (!ext.startsWith(".")) {
+                extSet.add("." + ext);
+            }
+            else {
+                extSet.add(ext);
+            }
+        }
+
+        return extSet;
     }
 }

--- a/src/main/java/ca/corbett/extras/io/FileSystemUtil.java
+++ b/src/main/java/ca/corbett/extras/io/FileSystemUtil.java
@@ -9,6 +9,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Enumeration;
 import java.util.HashSet;
@@ -130,6 +131,11 @@ public class FileSystemUtil {
             return new ArrayList<>();
         }
 
+        // If the extension list is empty, we match everything. No extension list means "no filter".
+        if (extSet.isEmpty()) {
+            return Arrays.asList(children);
+        }
+
         List<File> fileList = new ArrayList<>();
 
         for (File child : children) {
@@ -140,7 +146,7 @@ public class FileSystemUtil {
                 String filename = child.getName().toLowerCase();
 
                 // if any extensions match, it's a hit:
-                boolean fileMatched = extSet.isEmpty(); // empty list == automatic match
+                boolean fileMatched = false;
                 for (String ext : extSet) {
                     if (filename.endsWith(ext)) {
                         fileMatched = true;
@@ -696,13 +702,16 @@ public class FileSystemUtil {
     }
 
     /**
-     * Given a list of file extensions, which may be null or empty (and the list itself may also be
-     * null or empty), return a Set of normalized extensions. Normalization includes trimming whitespace, converting to
+     * Given a list of file extensions, which may be null or empty,
+     * return a Set of normalized extensions.
+     * Normalization includes trimming whitespace, converting to
      * lowercase, and ensuring that each extension starts with a dot.
+     * <p>
      * If the input list is null or empty, an empty set will be returned.
      * Any entry in the list that is null or blank will be ignored.
      * The returned set may be empty even in cases where the input list is not empty,
      * if all entries in the list are null or blank.
+     * </p>
      */
     static Set<String> normalizeExtensionsToSet(List<String> extensions) {
         if (extensions == null) {

--- a/src/main/resources/swing-extras/releaseNotes.txt
+++ b/src/main/resources/swing-extras/releaseNotes.txt
@@ -8,6 +8,7 @@ Version 3.0.0 [TODO - release date] - Major refactoring
   #452 - Fix FlatLaf Look and Feel bug on Windows systems
   #451 - Fix Windows-specific bug in File/DirectoryProperty
   #450 - Absorb the FileWatcher class from CryptText
+  #449 - Fix wonky behavior in FileSystemUtil.findFiles()
   #443 - Upgrade to Java 25
 
 Version 2.9.0 [2026-04-13] - Maintenance release

--- a/src/test/java/ca/corbett/extras/io/FileSystemUtilTest.java
+++ b/src/test/java/ca/corbett/extras/io/FileSystemUtilTest.java
@@ -130,7 +130,7 @@ public class FileSystemUtilTest {
     @Test
     public void testFindFiles_withRecursion_shouldSucceed() {
         assertEquals(1, FileSystemUtil.findFiles(rootDir1, true).size());
-        assertEquals(3, FileSystemUtil.findFiles(rootDir2, true).size());
+        assertEquals(2, FileSystemUtil.findFiles(rootDir2, true).size());
         assertEquals(1, FileSystemUtil.findFiles(rootDir3, true).size());
     }
 

--- a/src/test/java/ca/corbett/extras/io/FileSystemUtilTest.java
+++ b/src/test/java/ca/corbett/extras/io/FileSystemUtilTest.java
@@ -114,14 +114,14 @@ public class FileSystemUtilTest {
     public void testFindFilesExcluding_withExtensionList_shouldSucceed() {
         List<String> extensions = new ArrayList<>();
 
-        // Empty list matches everything, but this method is inverted, so we should get nothing:
-        assertEquals(0, FileSystemUtil.findFilesExcluding(rootDir1, true, extensions).size());
+        // Empty list with an inverted search means "return everything":
+        assertEquals(1, FileSystemUtil.findFilesExcluding(rootDir1, true, extensions).size());
 
-        // Searching for the "wrong" extension should match our file, because we've inverted the search:
+        // Inverted search with the "wrong" extension should return our file, because the extension is wrong:
         extensions.add("blah");
         assertEquals(1, FileSystemUtil.findFilesExcluding(rootDir1, true, extensions).size());
 
-        // Searching for the "right" extension should NOT find our file, because we've inverted the search:
+        // Inverted search with the "right" extension should return nothing, because we're excluding our file:
         extensions.clear();
         extensions.add("txt");
         assertEquals(0, FileSystemUtil.findFilesExcluding(rootDir1, true, extensions).size());
@@ -130,7 +130,7 @@ public class FileSystemUtilTest {
     @Test
     public void testFindFiles_withRecursion_shouldSucceed() {
         assertEquals(1, FileSystemUtil.findFiles(rootDir1, true).size());
-        assertEquals(2, FileSystemUtil.findFiles(rootDir2, true).size());
+        assertEquals(3, FileSystemUtil.findFiles(rootDir2, true).size());
         assertEquals(1, FileSystemUtil.findFiles(rootDir3, true).size());
     }
 
@@ -562,7 +562,7 @@ public class FileSystemUtilTest {
     }
 
     @Test
-    public void normalizeExtensionsToSet_withBlankOrNullEntiies_shouldReturnEmptySet() {
+    public void normalizeExtensionsToSet_withBlankOrNullEntries_shouldReturnEmptySet() {
         // GIVEN a list of extensions, all of which are null, empty, or blank:
         List<String> extensions = new ArrayList<>();
         extensions.add("   ");

--- a/src/test/java/ca/corbett/extras/io/FileSystemUtilTest.java
+++ b/src/test/java/ca/corbett/extras/io/FileSystemUtilTest.java
@@ -1,9 +1,8 @@
 package ca.corbett.extras.io;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
@@ -12,11 +11,9 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -27,23 +24,18 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 public class FileSystemUtilTest {
 
-    private static File testDir;
-    private static File rootDir1;
-    private static File rootDir2;
-    private static File rootDir3;
+    @TempDir
+    private File testDir;
+    private File rootDir1;
+    private File rootDir2;
+    private File rootDir3;
 
     public FileSystemUtilTest() {
     }
 
-    @BeforeAll
-    public static void setup() {
+    @BeforeEach
+    public void setup() {
         try {
-            File tmpdir = new File(System.getProperty("java.io.tmpdir"));
-            testDir = new File(tmpdir.getAbsolutePath() + "/sc-util-io-test");
-            if (testDir.exists()) {
-                tearDownClass();
-            }
-            testDir.mkdir();
             rootDir1 = new File(testDir, "rootDir1");
             rootDir2 = new File(testDir, "rootDir2");
             rootDir3 = new File(testDir, "rootDir3");
@@ -77,11 +69,6 @@ public class FileSystemUtilTest {
         }
     }
 
-    @AfterAll
-    public static void tearDownClass() {
-        delete(testDir);
-    }
-
     /**
      * If the input is a file, delete it, and if it's a directory,
      * recurse through it and delete it and everything it contains.
@@ -103,13 +90,18 @@ public class FileSystemUtilTest {
     @Test
     public void testFindFiles_withFileExtensionList_shouldSucceed() {
         List<String> extensions = new ArrayList<>();
-        assertEquals(0, FileSystemUtil.findFiles(rootDir1, true, extensions).size());
 
+        // Empty list should match our file:
+        assertEquals(1, FileSystemUtil.findFiles(rootDir1, true, extensions).size());
+
+        // Explicit extension search should find it:
         extensions.add("txt");
         assertEquals(1, FileSystemUtil.findFiles(rootDir1, true, extensions).size());
 
+        // Wrong extension search should not find it:
+        extensions.clear();
         extensions.add("blah");
-        assertEquals(1, FileSystemUtil.findFiles(rootDir1, true, extensions).size());
+        assertEquals(0, FileSystemUtil.findFiles(rootDir1, true, extensions).size());
     }
 
     @Test
@@ -121,11 +113,16 @@ public class FileSystemUtilTest {
     @Test
     public void testFindFilesExcluding_withExtensionList_shouldSucceed() {
         List<String> extensions = new ArrayList<>();
-        assertEquals(1, FileSystemUtil.findFilesExcluding(rootDir1, true, extensions).size());
 
+        // Empty list matches everything, but this method is inverted, so we should get nothing:
+        assertEquals(0, FileSystemUtil.findFilesExcluding(rootDir1, true, extensions).size());
+
+        // Searching for the "wrong" extension should match our file, because we've inverted the search:
         extensions.add("blah");
         assertEquals(1, FileSystemUtil.findFilesExcluding(rootDir1, true, extensions).size());
 
+        // Searching for the "right" extension should NOT find our file, because we've inverted the search:
+        extensions.clear();
         extensions.add("txt");
         assertEquals(0, FileSystemUtil.findFilesExcluding(rootDir1, true, extensions).size());
     }
@@ -267,30 +264,6 @@ public class FileSystemUtilTest {
         assertEquals("1.5 MB", FileSystemUtil.getPrintableSize(1024 * 1024 + 499999));
         assertEquals("1.0 GB", FileSystemUtil.getPrintableSize(1024 * 1024 * 1024));
         assertEquals("8192.0 PB", FileSystemUtil.getPrintableSize(Long.MAX_VALUE));
-    }
-
-    /**
-     * This one only works on my machine, and I don't want to check in a jar file as a test resource
-     * just for this purpose. So, this test is disabled by default.
-     * TODO find a better home for these "not really a unit test" tests, or delete them. There's 3 of them in total.
-     */
-    @Disabled
-    @Test
-    public void extractTextFileFromJar_withValidJar_shouldExtract() throws Exception {
-        // GIVEN a valid jar file with some text-based files in it:
-        File jarFile = new File("/home/scorbett/Software/sc-releases/extensions/ImageViewer/2.2/ext-iv-ice-2.2.0.jar");
-
-        // WHEN we try to extract some text files:
-        String value1 = FileSystemUtil.extractTextFileFromJar("extInfo.json", jarFile);
-        String value2 = FileSystemUtil.extractTextFileFromJar("META-INF/MANIFEST.MF", jarFile);
-        String value3 = FileSystemUtil.extractTextFileFromJar("does/not/exist", jarFile);
-
-        // THEN we should see expected results:
-        assertNotNull(value1);
-        assertFalse(value1.isEmpty());
-        assertNotNull(value2);
-        assertFalse(value2.isEmpty());
-        assertNull(value3);
     }
 
     @Test
@@ -580,6 +553,45 @@ public class FileSystemUtilTest {
         if (!conflict1.delete() || !conflict2.delete()) {
             fail("Unable to delete test files!");
         }
+    }
+
+    @Test
+    public void normalizeExtensionsToSet_withEmptyOrNullList_shouldReturnEmptySet() {
+        assertTrue(FileSystemUtil.normalizeExtensionsToSet(null).isEmpty());
+        assertTrue(FileSystemUtil.normalizeExtensionsToSet(new ArrayList<>()).isEmpty());
+    }
+
+    @Test
+    public void normalizeExtensionsToSet_withBlankOrNullEntiies_shouldReturnEmptySet() {
+        // GIVEN a list of extensions, all of which are null, empty, or blank:
+        List<String> extensions = new ArrayList<>();
+        extensions.add("   ");
+        extensions.add("");
+        extensions.add(null);
+
+        // WHEN we try to normalize them to a Set:
+        Set<String> result = FileSystemUtil.normalizeExtensionsToSet(extensions);
+
+        // THEN we should get back an empty Set, because all the entries were invalid:
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    public void normalizeExtensionsToSet_withMixedCaseExtensionsWithAndWithoutDots_shouldNormalize() {
+        // GIVEN a list of extensions with mixed case and some with leading dots:
+        List<String> extensions = new ArrayList<>();
+        extensions.add("txt");
+        extensions.add(".TXT");
+        extensions.add("BlAh");
+        extensions.add(".bLaH");
+
+        // WHEN we normalize them to a Set:
+        Set<String> result = FileSystemUtil.normalizeExtensionsToSet(extensions);
+
+        // THEN we should get back a Set with the normalized extensions, with dots, lowercase, without duplicates:
+        assertEquals(2, result.size());
+        assertTrue(result.contains(".txt"));
+        assertTrue(result.contains(".blah"));
     }
 
     private static void createNestedTestDir(File rootDir, int dirCount1, int dirCount2, int dirCount3, boolean createFiles)


### PR DESCRIPTION
This PR addresses issue #449 by fixing slightly wonky behavior in `FileSystemUtil.findFiles()`. Previously, supplying an empty list of file extensions would return no matches, because the logic in this method would only return exact extension matches. This is unexpected - an empty list of file extensions should return ALL files, because we effectively have supplied no filter. Also tightened up error handling throughout this method chain, to avoid null pointer exceptions and to ignore null or blank file extensions.

This is a potentially breaking change for applications that relied on the old behavior! This will be clearly documented in the release announcement when `3.0` goes out.

Updated and improved the tests for this class to prove out the new behavior.