### PR TITLE
Issue #467 - minor javadoc cleanup for field validators

### DIFF
--- a/src/main/java/ca/corbett/forms/validators/FileMustBeCreatableValidator.java
+++ b/src/main/java/ca/corbett/forms/validators/FileMustBeCreatableValidator.java
@@ -9,6 +9,7 @@ import java.io.File;
  * is in a location that can be written. Specifically, if you're browsing
  * for a new File which does NOT exist, it should be in a location where
  * we have permission to create a new file.
+ * The validator respects the field's allowBlankValues property, so blank values are validated as expected.
  *
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
  * @since 2019-11-27

--- a/src/main/java/ca/corbett/forms/validators/FileMustBeReadableValidator.java
+++ b/src/main/java/ca/corbett/forms/validators/FileMustBeReadableValidator.java
@@ -6,6 +6,7 @@ import java.io.File;
 
 /**
  * A FieldValidator that ensures that the chosen Directory can be read.
+ * The validator respects the field's allowBlankValues property, so blank values are validated as expected.
  *
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
  * @since 2019-11-24

--- a/src/main/java/ca/corbett/forms/validators/FileMustBeReadableValidator.java
+++ b/src/main/java/ca/corbett/forms/validators/FileMustBeReadableValidator.java
@@ -5,7 +5,7 @@ import ca.corbett.forms.fields.FileField;
 import java.io.File;
 
 /**
- * A FieldValidator that ensures that the chosen Directory can be read.
+ * A FieldValidator that ensures that the chosen file or directory can be read.
  * The validator respects the field's allowBlankValues property, so blank values are validated as expected.
  *
  * @author <a href="https://github.com/scorbo2">scorbo2</a>

--- a/src/main/java/ca/corbett/forms/validators/FileMustBeWritableValidator.java
+++ b/src/main/java/ca/corbett/forms/validators/FileMustBeWritableValidator.java
@@ -6,6 +6,7 @@ import java.io.File;
 
 /**
  * A FieldValidator that ensures that the chosen File can be written.
+ * The validator respects the field's allowBlankValues property, so blank values are validated as expected.
  *
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
  * @since 2019-11-24

--- a/src/main/java/ca/corbett/forms/validators/FileMustExistValidator.java
+++ b/src/main/java/ca/corbett/forms/validators/FileMustExistValidator.java
@@ -9,6 +9,7 @@ import java.io.File;
  * Also checks that the selection makes sense given the selection type of the
  * FileField in question. For example, if the selection type is DIRECTORIES_ONLY
  * and you select a file, that selection will fail validation.
+ * The validator respects the field's allowBlankValues property, so blank values are validated as expected.
  *
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
  * @since 2019-11-24

--- a/src/main/java/ca/corbett/forms/validators/FileMustNotBeDirectoryValidator.java
+++ b/src/main/java/ca/corbett/forms/validators/FileMustNotBeDirectoryValidator.java
@@ -4,6 +4,12 @@ import ca.corbett.forms.fields.FileField;
 
 import java.io.File;
 
+/**
+ * A simple validator that can be attached to any FileField to ensure that the selected file is not a directory.
+ * The validator respects the field's allowBlankValues property, so blank values are validated as expected.
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ */
 public class FileMustNotBeDirectoryValidator implements FieldValidator<FileField> {
     @Override
     public ValidationResult validate(FileField fieldToValidate) {

--- a/src/main/java/ca/corbett/forms/validators/FileMustNotExistValidator.java
+++ b/src/main/java/ca/corbett/forms/validators/FileMustNotExistValidator.java
@@ -7,6 +7,7 @@ import java.io.File;
 /**
  * The opposite of FileMustExistValidator, this one ensures that the selected file or directory
  * does not already exist (such as for a save dialog).
+ * The validator respects the field's allowBlankValues property, so blank values are validated as expected.
  *
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
  * @since 2019-11-24

--- a/src/main/java/ca/corbett/forms/validators/ListEmptySelectionValidator.java
+++ b/src/main/java/ca/corbett/forms/validators/ListEmptySelectionValidator.java
@@ -6,7 +6,8 @@ import ca.corbett.forms.fields.ListSubsetField;
 
 /**
  * A field validator that works with both ListField and ListSubsetField to ensure that
- * at least one item is selected.
+ * at least one item is selected. If attached to any other field type, this validator will always silently pass,
+ * without considering the field value.
  *
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
  * @since swing-extras 2.6

--- a/src/main/java/ca/corbett/forms/validators/NonBlankFieldValidator.java
+++ b/src/main/java/ca/corbett/forms/validators/NonBlankFieldValidator.java
@@ -7,7 +7,8 @@ import ca.corbett.forms.fields.ShortTextField;
 
 /**
  * A simple field validator for text fields that ensures that the field does not have a blank value.
- * Currently works with ShortTextField and LongTextField.
+ * Currently works with ShortTextField, LongTextField, and PasswordField. If attached to any other
+ * field type, this validator will always silently pass, without considering the field value.
  *
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
  * @since 2019-11-23

--- a/src/main/java/ca/corbett/forms/validators/YMDDateValidator.java
+++ b/src/main/java/ca/corbett/forms/validators/YMDDateValidator.java
@@ -6,7 +6,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 
 /**
- * A FieldValidator that enforces yyyy-mm-dd format on a given TextField.
+ * A FieldValidator that enforces yyyy-MM-dd format on a given TextField.
  * This is a bit cheesy but will do until and unless I ever put in a proper calendar chooser.
  *
  * @author <a href="https://github.com/scorbo2">scorbo2</a>

--- a/src/main/java/ca/corbett/forms/validators/YMDDateValidator.java
+++ b/src/main/java/ca/corbett/forms/validators/YMDDateValidator.java
@@ -31,7 +31,7 @@ public class YMDDateValidator implements FieldValidator<ShortTextField> {
             format.parse(currentStr);
         }
         catch (ParseException e) {
-            return ValidationResult.invalid("Value must be in format: yyyy-mm-dd");
+            return ValidationResult.invalid("Value must be in format: yyyy-MM-dd");
         }
         return ValidationResult.valid();
     }

--- a/src/main/java/ca/corbett/forms/validators/package-info.java
+++ b/src/main/java/ca/corbett/forms/validators/package-info.java
@@ -7,9 +7,11 @@
  * <p>
  * You can, of course, provide your own FieldValidator implementation, if you have
  * specific business logic or validation rules that you need to use.
+ * </p>
  * <p>
  * If multiple FieldValidators are assigned to a FormField, they will each be invoked,
  * and all of them must return a successful validation in order for the field to
  * be considered valid.
+ * </p>
  */
 package ca.corbett.forms.validators;

--- a/src/main/resources/swing-extras/releaseNotes.txt
+++ b/src/main/resources/swing-extras/releaseNotes.txt
@@ -4,6 +4,7 @@ Author: Steve Corbett
 Version 3.0.0 [TODO - release date] - Major refactoring
   #475 - LongTextProperty: add row limit for dynamic multiline
   #470 - Make ResourceLoader more flexible with class loaders
+  #467 - Minor javadoc cleanup for form validators
   #456 - Upgrade all dependency versions to latest
   #455 - Drop support for JTattoo
   #453 - Fix bug in ActionPanel demo panel


### PR DESCRIPTION
This PR addresses issue #467 by doing a javadoc cleanup pass in the `validators` package. Also fixed a bad validation message which referenced an incorrect date format.