### PR TITLE
Issue #472 - better resizing of OK button on TextInputDialog

### DIFF
--- a/src/main/java/ca/corbett/extras/TextInputDialog.java
+++ b/src/main/java/ca/corbett/extras/TextInputDialog.java
@@ -256,6 +256,17 @@ public class TextInputDialog extends JDialog {
      */
     public TextInputDialog setConfirmLabel(String label) {
         okButton.setText(label);
+
+        // The button was initialized with a hard-coded size which may no longer fit the label.
+        // Let's remove the hard-coded size and let the button resize itself to fit the new label:
+        okButton.setPreferredSize(null);
+        okButton.revalidate();
+        okButton.repaint();
+        int newWidth = Math.max(okButton.getPreferredSize().width, 100); // enforce a minimum width of 100
+        newWidth = Math.min(newWidth, 200); // enforce a maximum width of 200 to prevent it from getting absurdly wide
+        okButton.setPreferredSize(new Dimension(newWidth, 24)); // keep the right height
+        okButton.revalidate();
+        okButton.repaint();
         return this;
     }
 

--- a/src/main/java/ca/corbett/extras/TextInputDialog.java
+++ b/src/main/java/ca/corbett/extras/TextInputDialog.java
@@ -260,13 +260,11 @@ public class TextInputDialog extends JDialog {
         // The button was initialized with a hard-coded size which may no longer fit the label.
         // Let's remove the hard-coded size and let the button resize itself to fit the new label:
         okButton.setPreferredSize(null);
-        okButton.revalidate();
-        okButton.repaint();
         int newWidth = Math.max(okButton.getPreferredSize().width, 100); // enforce a minimum width of 100
         newWidth = Math.min(newWidth, 200); // enforce a maximum width of 200 to prevent it from getting absurdly wide
         okButton.setPreferredSize(new Dimension(newWidth, 24)); // keep the right height
-        okButton.revalidate();
-        okButton.repaint();
+        getContentPane().revalidate();
+        getContentPane().repaint();
         return this;
     }
 

--- a/src/main/resources/swing-extras/releaseNotes.txt
+++ b/src/main/resources/swing-extras/releaseNotes.txt
@@ -3,6 +3,7 @@ Author: Steve Corbett
 
 Version 3.0.0 [TODO - release date] - Major refactoring
   #475 - LongTextProperty: add row limit for dynamic multiline
+  #472 - TextInputDialog: better resizing of confirm button
   #470 - Make ResourceLoader more flexible with class loaders
   #467 - Minor javadoc cleanup for form validators
   #456 - Upgrade all dependency versions to latest


### PR DESCRIPTION
This PR addresses issue #472 by allowing some flexible auto-sizing of the confirm button on `TextInputDialog` if it is changed from the default label ("OK"). The button now auto-resizes within certain reasonable bounds.