### PR TITLE
Issue #469 - slight tweak to ExtensionManager load order logic

### DIFF
--- a/src/main/java/ca/corbett/extensions/AppExtension.java
+++ b/src/main/java/ca/corbett/extensions/AppExtension.java
@@ -84,13 +84,16 @@ public abstract class AppExtension {
     protected abstract List<AbstractProperty> createConfigProperties();
 
     /**
-     * This method is invoked exactly once when an extension is dynamically loaded from
-     * a jar file. If the extension has resources (images, sound effects, icons, text files,
-     * config files, or any other resource type) that it wishes to load from its jar file
-     * via class.getResource() or class.getResourceAsStream(), it MUST do it either in its
-     * constructor or in this method. Attempting to load jar resources anywhere else in the
-     * extension will fail, because the URLClassLoader that loads the extension is closed
-     * by ExtensionManager immediately after the extension is instantiated.
+     * This method is invoked exactly once when an extension is loaded.
+     * For internal extensions, this is largely irrelevant, since resources are loaded
+     * from the application's jar file and can be done from anywhere in the extension.
+     * But, if your extension is externally loaded, it is important to note that the URLClassLoader
+     * that loads your extension will be closed by ExtensionManager after your extension is initialized!
+     * If your extension has resources (images, sound effects, icons, text files,
+     * config files, or any other resource type) that you wish it to load from its jar file
+     * via class.getResource() or class.getResourceAsStream(), you MUST do it either in the extension
+     * constructor or in this method. Attempting to load jar resources anywhere else in you
+     * extension will fail, because the URLClassLoader that loads the extension is closed.
      * No default implementation is provided so that extensions are forced to implement
      * this method (even if empty, in the case of an extension with no resources to load).
      * <p>
@@ -99,6 +102,11 @@ public abstract class AppExtension {
      * depend on resources that need to be loaded from the extension's jar file, you can
      * safely load those resources in this method, and then reference the loaded resources
      * in your implementation of createConfigProperties().
+     * </p>
+     * <p>
+     * <b>NOTE:</b> the extension's configProperties list has not yet been initialized! Don't try
+     * to access it here. ExtensionManager will catch the NullPointerException and log a warning, so it
+     * won't break the load, but it is bad form and should be avoided.
      * </p>
      */
     protected abstract void loadJarResources();

--- a/src/main/java/ca/corbett/extensions/AppExtension.java
+++ b/src/main/java/ca/corbett/extensions/AppExtension.java
@@ -37,7 +37,7 @@ public abstract class AppExtension {
     /**
      * Return a list of configuration properties for this extension. This list may be
      * empty if the extension has no config properties. This method is final to
-     * prevent extensions from overriding its behaviour. The intention is to force
+     * prevent extensions from overriding its behavior. The intention is to force
      * extensions to implement createConfigProperties() to create the list.
      * The createConfigProperties() method is guaranteed to only be invoked
      * by the ExtensionManager once, whereas getConfigProperties() can be invoked
@@ -72,6 +72,12 @@ public abstract class AppExtension {
      * AbstractProperty instances representing the config for this extension.
      * It's fine to return null or an empty list if your extension does
      * not require any configuration.
+     * <p>
+     * Note that this method is invoked (exactly once) by ExtensionManager, <b>after</b> the
+     * <code>loadJarResources</code> method is invoked. So, if your extension's config properties
+     * depend on resources that need to be loaded from the extension's jar file,
+     * you can safely reference those loaded resources in your implementation of this method.
+     * </p>
      *
      * @return A List of AbstractProperty instance. May be null or empty.
      */
@@ -87,6 +93,13 @@ public abstract class AppExtension {
      * by ExtensionManager immediately after the extension is instantiated.
      * No default implementation is provided so that extensions are forced to implement
      * this method (even if empty, in the case of an extension with no resources to load).
+     * <p>
+     * This method is invoked by ExtensionManager immediately after the extension is instantiated, and before
+     * the createConfigProperties() method is invoked. So, if your extension's config properties
+     * depend on resources that need to be loaded from the extension's jar file, you can
+     * safely load those resources in this method, and then reference the loaded resources
+     * in your implementation of createConfigProperties().
+     * </p>
      */
     protected abstract void loadJarResources();
 }

--- a/src/main/java/ca/corbett/extensions/AppExtension.java
+++ b/src/main/java/ca/corbett/extensions/AppExtension.java
@@ -92,7 +92,7 @@ public abstract class AppExtension {
      * If your extension has resources (images, sound effects, icons, text files,
      * config files, or any other resource type) that you wish it to load from its jar file
      * via class.getResource() or class.getResourceAsStream(), you MUST do it either in the extension
-     * constructor or in this method. Attempting to load jar resources anywhere else in you
+     * constructor or in this method. Attempting to load jar resources anywhere else in your
      * extension will fail, because the URLClassLoader that loads the extension is closed.
      * No default implementation is provided so that extensions are forced to implement
      * this method (even if empty, in the case of an extension with no resources to load).
@@ -105,8 +105,8 @@ public abstract class AppExtension {
      * </p>
      * <p>
      * <b>NOTE:</b> the extension's configProperties list has not yet been initialized! Don't try
-     * to access it here. ExtensionManager will catch the NullPointerException and log a warning, so it
-     * won't break the load, but it is bad form and should be avoided.
+     * to access it here. It won't break the load if you do, but the list will be empty, and trying
+     * to manipulate it will not have any effect (other than a nag warning in the log from ExtensionManager).
      * </p>
      */
     protected abstract void loadJarResources();

--- a/src/main/java/ca/corbett/extensions/ExtensionManager.java
+++ b/src/main/java/ca/corbett/extensions/ExtensionManager.java
@@ -774,17 +774,17 @@ public abstract class ExtensionManager<T extends AppExtension> {
                                 continue;
                             }
 
+                            // We can also invoke loadJarResources now while the class loader is still open:
+                            // An extension should use this as an opportunity to load resources from its jar file,
+                            // because we're about to close the class loader that loaded it!
+                            result.loadJarResources();
+
                             // Invoke createConfigProperties() and set the configProperties list for this extension:
                             // (this was formerly invoked from the extension constructor, but that was BAD...
                             //  see issue https://github.com/scorbo2/swing-extras/issues/116 for details.
-                            //  We can safely do it from here.)
+                            //  We can safely do it from here, now that the instance is initialized.)
                             List<AbstractProperty> configProperties = result.createConfigProperties();
                             result.configProperties = configProperties == null ? new ArrayList<>() : configProperties;
-
-                            // We can also invoke loadJarResources now while the class loader is still open:
-                            // This is an extension class's last opportunity to load resources from its jar file,
-                            // because we're about to close the class loader that loaded it!
-                            result.loadJarResources();
                         }
                         catch (NoSuchMethodException ignored) {
                             // Extensions must supply a no-argument constructor:

--- a/src/main/java/ca/corbett/extensions/ExtensionManager.java
+++ b/src/main/java/ca/corbett/extensions/ExtensionManager.java
@@ -385,6 +385,7 @@ public abstract class ExtensionManager<T extends AppExtension> {
         wrapper.sourceJar = null;
         wrapper.isEnabled = isEnabled;
         wrapper.extension = extension;
+        extension.loadJarResources(); // internal extensions load resources from the application's jar file, but okay
         List<AbstractProperty> configProperties = extension.createConfigProperties();
         extension.configProperties = configProperties == null ? new ArrayList<>() : configProperties;
         loadedExtensions.put(extension.getClass().getName(), wrapper);

--- a/src/main/java/ca/corbett/extensions/ExtensionManager.java
+++ b/src/main/java/ca/corbett/extensions/ExtensionManager.java
@@ -386,12 +386,12 @@ public abstract class ExtensionManager<T extends AppExtension> {
         wrapper.isEnabled = isEnabled;
         wrapper.extension = extension;
 
-        try {
-            // internal extensions load resources from the application's jar file, but for consistency
-            // with the "load from jar file" flow, we will invoke this method here.
-            extension.loadJarResources();
-        }
-        catch (NullPointerException ignored) {
+        // internal extensions load resources from the application's jar file, but for consistency
+        // with the "load from jar file" flow, we will invoke this method here.
+        List<AbstractProperty> dummyList = new ArrayList<>();
+        extension.configProperties = dummyList;
+        extension.loadJarResources();
+        if (!dummyList.isEmpty()) {
             logger.warning("Don't try to access configProperties from the loadJarResources() method!");
         }
 
@@ -787,10 +787,10 @@ public abstract class ExtensionManager<T extends AppExtension> {
                             // We can also invoke loadJarResources now while the class loader is still open:
                             // An extension should use this as an opportunity to load resources from its jar file,
                             // because we're about to close the class loader that loaded it!
-                            try {
-                                result.loadJarResources();
-                            }
-                            catch (NullPointerException ignored) {
+                            List<AbstractProperty> dummyList = new ArrayList<>();
+                            result.configProperties = dummyList;
+                            result.loadJarResources();
+                            if (!dummyList.isEmpty()) {
                                 logger.warning("Don't try to access configProperties " +
                                                        "from the loadJarResources() method!");
                             }

--- a/src/main/java/ca/corbett/extensions/ExtensionManager.java
+++ b/src/main/java/ca/corbett/extensions/ExtensionManager.java
@@ -385,7 +385,16 @@ public abstract class ExtensionManager<T extends AppExtension> {
         wrapper.sourceJar = null;
         wrapper.isEnabled = isEnabled;
         wrapper.extension = extension;
-        extension.loadJarResources(); // internal extensions load resources from the application's jar file, but okay
+
+        try {
+            // internal extensions load resources from the application's jar file, but for consistency
+            // with the "load from jar file" flow, we will invoke this method here.
+            extension.loadJarResources();
+        }
+        catch (NullPointerException ignored) {
+            logger.warning("Don't try to access configProperties from the loadJarResources() method!");
+        }
+
         List<AbstractProperty> configProperties = extension.createConfigProperties();
         extension.configProperties = configProperties == null ? new ArrayList<>() : configProperties;
         loadedExtensions.put(extension.getClass().getName(), wrapper);
@@ -778,7 +787,13 @@ public abstract class ExtensionManager<T extends AppExtension> {
                             // We can also invoke loadJarResources now while the class loader is still open:
                             // An extension should use this as an opportunity to load resources from its jar file,
                             // because we're about to close the class loader that loaded it!
-                            result.loadJarResources();
+                            try {
+                                result.loadJarResources();
+                            }
+                            catch (NullPointerException ignored) {
+                                logger.warning("Don't try to access configProperties " +
+                                                       "from the loadJarResources() method!");
+                            }
 
                             // Invoke createConfigProperties() and set the configProperties list for this extension:
                             // (this was formerly invoked from the extension constructor, but that was BAD...

--- a/src/main/resources/swing-extras/releaseNotes.txt
+++ b/src/main/resources/swing-extras/releaseNotes.txt
@@ -5,6 +5,7 @@ Version 3.0.0 [TODO - release date] - Major refactoring
   #475 - LongTextProperty: add row limit for dynamic multiline
   #472 - TextInputDialog: better resizing of confirm button
   #470 - Make ResourceLoader more flexible with class loaders
+  #469 - Minor tweak to ExtensionManager's load order logic
   #467 - Minor javadoc cleanup for form validators
   #456 - Upgrade all dependency versions to latest
   #455 - Drop support for JTattoo

--- a/src/test/java/ca/corbett/extensions/ExtensionManagerTest.java
+++ b/src/test/java/ca/corbett/extensions/ExtensionManagerTest.java
@@ -16,6 +16,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Logger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -151,7 +152,24 @@ public class ExtensionManagerTest {
         AppExtensionImpl1 extension = new AppExtensionImpl1("test");
         boolean success = extManager.addExtension(extension, true);
         assertTrue(success);
-        assertTrue(extension.isJarResourcesWereLoadedBeforeConfigPropertiesCreated());
+        assertTrue(extension.isJarResourcesLoadedBeforeConfigPropertiesCreated());
+    }
+
+    @Test
+    public void testLoadLogic_accessConfigPropertiesInLoadJarResources_shouldLogWarning() {
+        // Use our log capturing mechanism to spy on ExtensionManager:
+        AppPropertiesTest.TestLogHandler logHandler = new AppPropertiesTest.TestLogHandler();
+        Logger testLogger = Logger.getLogger(ExtensionManager.class.getName());
+        testLogger.addHandler(logHandler);
+
+        try {
+            extManager.addExtension(new MisbehavingExtension("misbehaving"), true);
+            assertTrue(logHandler.hasWarningContaining(
+                    "Don't try to access configProperties from the loadJarResources() method!"));
+        }
+        finally {
+            testLogger.removeHandler(logHandler);
+        }
     }
 
     @Test
@@ -645,12 +663,12 @@ public class ExtensionManagerTest {
 
         private final String name;
         private boolean jarResourcesLoaded;
-        private boolean jarResourcesWereLoadedBeforeConfigPropertiesCreated;
+        private boolean jarResourcesLoadedBeforeConfigPropertiesCreated;
 
         public AppExtensionImpl1(String name) {
             this.name = name;
             jarResourcesLoaded = false;
-            jarResourcesWereLoadedBeforeConfigPropertiesCreated = false;
+            jarResourcesLoadedBeforeConfigPropertiesCreated = false;
         }
 
         @Override
@@ -666,8 +684,8 @@ public class ExtensionManagerTest {
                     .build();
         }
 
-        public boolean isJarResourcesWereLoadedBeforeConfigPropertiesCreated() {
-            return jarResourcesWereLoadedBeforeConfigPropertiesCreated;
+        public boolean isJarResourcesLoadedBeforeConfigPropertiesCreated() {
+            return jarResourcesLoadedBeforeConfigPropertiesCreated;
         }
 
         @Override
@@ -680,7 +698,7 @@ public class ExtensionManagerTest {
             if (jarResourcesLoaded) {
                 // Testing the fix for issue 469 - loadJarResources() should be called
                 // before createConfigProperties(), so jarResourcesLoaded should be true here.
-                jarResourcesWereLoadedBeforeConfigPropertiesCreated = true;
+                jarResourcesLoadedBeforeConfigPropertiesCreated = true;
             }
             return null;
         }
@@ -720,6 +738,46 @@ public class ExtensionManagerTest {
             List<AbstractProperty> list = new ArrayList<>();
             list.add(new IntegerProperty("testProperty", "testProperty", 1));
             return list;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+
+    /**
+     * This extension tries to access its configProperties in the loadJarResource() method,
+     * which is a no-no because loadJarResources() is called before createConfigProperties().
+     */
+    public static class MisbehavingExtension extends AppExtension {
+
+        private final String name;
+
+        public MisbehavingExtension(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public AppExtensionInfo getInfo() {
+            return new AppExtensionInfo.Builder(name)
+                    .setAuthor("me2")
+                    .setVersion("1.1")
+                    .setTargetAppName("Test app")
+                    .setTargetAppVersion("1.1")
+                    .setShortDescription("Misbehaving")
+                    .setLongDescription("I fought the law and the law won")
+                    .setReleaseNotes("v1.1 - initial release")
+                    .build();
+        }
+
+        @Override
+        protected void loadJarResources() {
+            configProperties.clear(); // Whoops! This list doesn't exist yet. Hello, NullPointerException!
+        }
+
+        @Override
+        protected List<AbstractProperty> createConfigProperties() {
+            return null;
         }
 
         public String getName() {

--- a/src/test/java/ca/corbett/extensions/ExtensionManagerTest.java
+++ b/src/test/java/ca/corbett/extensions/ExtensionManagerTest.java
@@ -746,7 +746,7 @@ public class ExtensionManagerTest {
     }
 
     /**
-     * This extension tries to access its configProperties in the loadJarResource() method,
+     * This extension tries to access its configProperties in the loadJarResources() method,
      * which is a no-no because loadJarResources() is called before createConfigProperties().
      */
     public static class MisbehavingExtension extends AppExtension {
@@ -772,7 +772,12 @@ public class ExtensionManagerTest {
 
         @Override
         protected void loadJarResources() {
-            configProperties.clear(); // Whoops! This list doesn't exist yet. Hello, NullPointerException!
+            // Whoops! We ignored the javadocs in AppExtension, and we're trying to manipulate
+            // our configProperties list before it's been properly initialized!
+            // ExtensionManager should catch this and log a nag warning:
+            configProperties.add(new IntegerProperty("shouldNotBeAccessingConfigProperties",
+                                                     "shouldNotBeAccessingConfigProperties",
+                                                     1));
         }
 
         @Override

--- a/src/test/java/ca/corbett/extensions/ExtensionManagerTest.java
+++ b/src/test/java/ca/corbett/extensions/ExtensionManagerTest.java
@@ -146,6 +146,15 @@ public class ExtensionManagerTest {
     }
 
     @Test
+    public void testLoadOrder_jarResourcesShouldBeLoadedBeforeConfigPropertiesCreated() {
+        // Issue #469 - loadJarResources() must be called before createConfigProperties:
+        AppExtensionImpl1 extension = new AppExtensionImpl1("test");
+        boolean success = extManager.addExtension(extension, true);
+        assertTrue(success);
+        assertTrue(extension.isJarResourcesWereLoadedBeforeConfigPropertiesCreated());
+    }
+
+    @Test
     public void testUnloadExtension() {
         boolean success = extManager.addExtension(ext1, true);
         assertTrue(success);
@@ -635,9 +644,13 @@ public class ExtensionManagerTest {
     public static class AppExtensionImpl1 extends AppExtension {
 
         private final String name;
+        private boolean jarResourcesLoaded;
+        private boolean jarResourcesWereLoadedBeforeConfigPropertiesCreated;
 
         public AppExtensionImpl1(String name) {
             this.name = name;
+            jarResourcesLoaded = false;
+            jarResourcesWereLoadedBeforeConfigPropertiesCreated = false;
         }
 
         @Override
@@ -653,12 +666,22 @@ public class ExtensionManagerTest {
                     .build();
         }
 
+        public boolean isJarResourcesWereLoadedBeforeConfigPropertiesCreated() {
+            return jarResourcesWereLoadedBeforeConfigPropertiesCreated;
+        }
+
         @Override
         protected void loadJarResources() {
+            jarResourcesLoaded = true;
         }
 
         @Override
         protected List<AbstractProperty> createConfigProperties() {
+            if (jarResourcesLoaded) {
+                // Testing the fix for issue 469 - loadJarResources() should be called
+                // before createConfigProperties(), so jarResourcesLoaded should be true here.
+                jarResourcesWereLoadedBeforeConfigPropertiesCreated = true;
+            }
             return null;
         }
 


### PR DESCRIPTION
This PR addresses issue #469 by making a slight change to the load order logic for application extensions in `ExtensionManager`. We now invoke `loadJarResources()` before `createConfigProperties()`. Some extensions need to load resources from their jar files in order to properly create their config properties (for example, loading a text resource to be used as a default value for a text-based property). With the previous load order, this forced extensions to load their resources in the extension constructor, so that they could be referenced by `createConfigProperties()`. With this change in place, extensions can move that logic to `loadJarResources()` where it belongs.

Updated method javadocs in `AppExtension` to make this clear to application extension developers.