### PR TITLE
Issue #473 - TextInputDialog - allow help text for input field

### DIFF
--- a/src/main/java/ca/corbett/extras/TextInputDialog.java
+++ b/src/main/java/ca/corbett/extras/TextInputDialog.java
@@ -76,7 +76,7 @@ public class TextInputDialog extends JDialog {
         longTextField = LongTextField.ofDynamicSizingMultiLine(DEFAULT_PROMPT, getRows());
         formPanel.add(inputType == InputType.SingleLine ? shortTextField : longTextField);
         Dimension dim = switch (inputType) {
-            case SingleLine -> new Dimension(350, 150);
+            case SingleLine -> new Dimension(380, 150);
             case MultiLine -> new Dimension(400, 300);
         };
         setSize(dim);
@@ -157,6 +157,30 @@ public class TextInputDialog extends JDialog {
         }
         dialog.setVisible(true);
         return dialog.getResult();
+    }
+
+    /**
+     * Optionally, you can specify help text to attach to the text input field.
+     * The default is no help text. If specified, an information icon will appear
+     * next to the text field, and hovering over it will show the given help text in a tooltip.
+     *
+     * @param helpText Any help text. Use html tags with br tags for multi-line help text. Null or blank disables help.
+     * @return This dialog, for method chaining.
+     */
+    public TextInputDialog setHelpText(String helpText) {
+        shortTextField.setHelpText(helpText);
+        longTextField.setHelpText(helpText);
+        return this;
+    }
+
+    /**
+     * Returns the current help text attached to the text input field, or null if no help text is set.
+     *
+     * @return The current help text attached to the text input field, or null if no help text is set.
+     */
+    public String getHelpText() {
+        // both fields will always have the same help text, so just return from one of them:
+        return shortTextField.getHelpText();
     }
 
     /**

--- a/src/main/java/ca/corbett/extras/demo/panels/TextInputDialogPanel.java
+++ b/src/main/java/ca/corbett/extras/demo/panels/TextInputDialogPanel.java
@@ -38,6 +38,7 @@ public class TextInputDialogPanel extends PanelBuilder {
     private ShortTextField disallowedTextField;
     private ComboField<String> inputTypeCombo;
     private NumberField minLengthField;
+    private ShortTextField helpTextField;
     private LabelField resultLabel;
 
     @Override
@@ -89,6 +90,10 @@ public class TextInputDialogPanel extends PanelBuilder {
         minLengthField.setHelpText("<html>Adding custom validation is easy! Here's one possible example.<br>" +
                                            "Set to 0 to disable this validator.</html>");
         formPanel.add(minLengthField);
+
+        helpTextField = new ShortTextField("Help text:", 25);
+        helpTextField.setHelpText("Sets optional help text to appear beside the input field.");
+        formPanel.add(helpTextField);
 
         ButtonField buttonField = new ButtonField(List.of(new LaunchDialogAction()));
         formPanel.add(buttonField);
@@ -196,6 +201,8 @@ public class TextInputDialogPanel extends PanelBuilder {
 
             int minLength = minLengthField.getCurrentValue().intValue();
             dialog.setAllowBlank(minLength == 0);
+
+            dialog.setHelpText(helpTextField.getText().trim());
 
             // Add our custom validator:
             dialog.addValidator(new ExampleValidator());

--- a/src/main/resources/swing-extras/releaseNotes.txt
+++ b/src/main/resources/swing-extras/releaseNotes.txt
@@ -3,6 +3,7 @@ Author: Steve Corbett
 
 Version 3.0.0 [TODO - release date] - Major refactoring
   #475 - LongTextProperty: add row limit for dynamic multiline
+  #473 - TextInputDialog: allow setting help text for input field
   #472 - TextInputDialog: better resizing of confirm button
   #470 - Make ResourceLoader more flexible with class loaders
   #469 - Minor tweak to ExtensionManager's load order logic


### PR DESCRIPTION
This PR addresses issue #473 by adding optional help text support in the `TextInputDialog`. The default behavior is not to show help text, to match the previous behavior. But callers now have the option of setting help text to be displayed next to the input field.

Updated the demo app to show off the new ability.