### PR TITLE
Issue #471 - TextInputDialog: add optional overview label

### DIFF
--- a/src/main/java/ca/corbett/extras/TextInputDialog.java
+++ b/src/main/java/ca/corbett/extras/TextInputDialog.java
@@ -3,6 +3,7 @@ package ca.corbett.extras;
 import ca.corbett.extras.io.KeyStrokeManager;
 import ca.corbett.forms.Alignment;
 import ca.corbett.forms.FormPanel;
+import ca.corbett.forms.Margins;
 import ca.corbett.forms.fields.FormField;
 import ca.corbett.forms.fields.LabelField;
 import ca.corbett.forms.fields.LongTextField;
@@ -14,6 +15,7 @@ import javax.swing.BorderFactory;
 import javax.swing.JButton;
 import javax.swing.JDialog;
 import javax.swing.JPanel;
+import javax.swing.JScrollPane;
 import javax.swing.text.JTextComponent;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
@@ -73,8 +75,13 @@ public class TextInputDialog extends JDialog {
         this.keyStrokeManager = new KeyStrokeManager(this);
 
         formPanel = new FormPanel(Alignment.TOP_CENTER);
-        formPanel.setBorderMargin(12);
+        formPanel.setBorderMargin(new Margins(12, 0, 12, 12, 0));
 
+        // FormPanel applies its border margin to the 0th component.
+        // This is a problem, because we're deliberately hiding the overview label by default.
+        // So, we tell the FormPanel to have a top margin of 0, and then we'll add a spacer
+        // panel above it to create the desired top margin. This is pretty hacky,
+        // but it works.
         overviewLabel = new LabelField("");
         overviewLabel.setVisible(false);
         formPanel.add(overviewLabel);
@@ -109,8 +116,16 @@ public class TextInputDialog extends JDialog {
         buttonPanel.add(okButton);
         buttonPanel.add(cancelButton);
 
+        JPanel spacerPanel = new JPanel();
+        spacerPanel.setBorder(null); // set null border to hide the fact we're using a hacky spacer panel
+        spacerPanel.setPreferredSize(new Dimension(1, 12));
+        formPanel.setBorder(null); // likewise, null border on the form panel to hide the hack
+
         setLayout(new BorderLayout());
-        add(ScrollUtil.buildScrollPane(formPanel), BorderLayout.CENTER);
+        add(spacerPanel, BorderLayout.NORTH);
+        JScrollPane scrollPane = ScrollUtil.buildScrollPane(formPanel);
+        scrollPane.setBorder(null); // even the scroll pane has to have a null border, sigh
+        add(scrollPane, BorderLayout.CENTER);
         add(buttonPanel, BorderLayout.SOUTH);
 
         if (owner != null) {
@@ -190,7 +205,7 @@ public class TextInputDialog extends JDialog {
      * and using br tags for line breaks.
      * </p>
      *
-     * @param overviewText Any overview text. Null or blank values hides the overview label.
+     * @param overviewText Any overview text. Null or blank values hide the overview label.
      * @return This dialog, for method chaining.
      */
     public TextInputDialog setOverviewText(String overviewText) {

--- a/src/main/java/ca/corbett/extras/TextInputDialog.java
+++ b/src/main/java/ca/corbett/extras/TextInputDialog.java
@@ -4,6 +4,7 @@ import ca.corbett.extras.io.KeyStrokeManager;
 import ca.corbett.forms.Alignment;
 import ca.corbett.forms.FormPanel;
 import ca.corbett.forms.fields.FormField;
+import ca.corbett.forms.fields.LabelField;
 import ca.corbett.forms.fields.LongTextField;
 import ca.corbett.forms.fields.ShortTextField;
 import ca.corbett.forms.validators.FieldValidator;
@@ -43,6 +44,7 @@ public class TextInputDialog extends JDialog {
     protected final InputType inputType;
     protected final KeyStrokeManager keyStrokeManager;
     protected FormPanel formPanel;
+    protected LabelField overviewLabel;
     protected ShortTextField shortTextField;
     protected LongTextField longTextField;
     protected JButton okButton;
@@ -72,6 +74,11 @@ public class TextInputDialog extends JDialog {
 
         formPanel = new FormPanel(Alignment.TOP_CENTER);
         formPanel.setBorderMargin(12);
+
+        overviewLabel = new LabelField("");
+        overviewLabel.setVisible(false);
+        formPanel.add(overviewLabel);
+
         shortTextField = new ShortTextField(DEFAULT_PROMPT, getCols());
         longTextField = LongTextField.ofDynamicSizingMultiLine(DEFAULT_PROMPT, getRows());
         formPanel.add(inputType == InputType.SingleLine ? shortTextField : longTextField);
@@ -170,6 +177,32 @@ public class TextInputDialog extends JDialog {
     public TextInputDialog setHelpText(String helpText) {
         shortTextField.setHelpText(helpText);
         longTextField.setHelpText(helpText);
+        return this;
+    }
+
+    /**
+     * Sets optional overview text to appear at the top of the dialog, above the text input field.
+     * This is useful for providing context as to what the user is supposed to input, or any other relevant information.
+     * By default, no overview text is shown. The form panel will scroll vertically if needed, but you might
+     * want to increase the height of the dialog if your overview text is large.
+     * <p>
+     * <b>Multi-line overview text:</b> you can accomplish this by wrapping the label text in html tags,
+     * and using br tags for line breaks.
+     * </p>
+     *
+     * @param overviewText Any overview text. Null or blank values hides the overview label.
+     * @return This dialog, for method chaining.
+     */
+    public TextInputDialog setOverviewText(String overviewText) {
+        overviewLabel.setText(overviewText);
+        boolean oldVisibility = overviewLabel.isVisible();
+        boolean newVisibility = overviewText != null && !overviewText.isBlank();
+        overviewLabel.setVisible(newVisibility);
+        if (oldVisibility != newVisibility) {
+            // If the visibility changed, we need to revalidate and repaint to update the layout:
+            formPanel.revalidate();
+            formPanel.repaint();
+        }
         return this;
     }
 

--- a/src/main/java/ca/corbett/extras/demo/panels/TextInputDialogPanel.java
+++ b/src/main/java/ca/corbett/extras/demo/panels/TextInputDialogPanel.java
@@ -39,6 +39,7 @@ public class TextInputDialogPanel extends PanelBuilder {
     private ComboField<String> inputTypeCombo;
     private NumberField minLengthField;
     private ShortTextField helpTextField;
+    private ShortTextField overviewTextField;
     private LabelField resultLabel;
 
     @Override
@@ -94,6 +95,11 @@ public class TextInputDialogPanel extends PanelBuilder {
         helpTextField = new ShortTextField("Help text:", 25);
         helpTextField.setHelpText("Sets optional help text to appear beside the input field.");
         formPanel.add(helpTextField);
+
+        overviewTextField = new ShortTextField("Overview text:", 25);
+        overviewTextField.setHelpText("Sets optional overview text to appear at the top of the dialog.");
+        overviewTextField.setText("<html><b>Overview</b><br>You can set optional overview text, if you want.</html>");
+        formPanel.add(overviewTextField);
 
         ButtonField buttonField = new ButtonField(List.of(new LaunchDialogAction()));
         formPanel.add(buttonField);
@@ -203,6 +209,12 @@ public class TextInputDialogPanel extends PanelBuilder {
             dialog.setAllowBlank(minLength == 0);
 
             dialog.setHelpText(helpTextField.getText().trim());
+
+            // Give it a little extra vertical height if the user gave us overview text:
+            if (!overviewTextField.getText().trim().isBlank()) {
+                dialog.setOverviewText(overviewTextField.getText().trim());
+                dialog.setSize(dialog.getWidth(), dialog.getHeight() + 50);
+            }
 
             // Add our custom validator:
             dialog.addValidator(new ExampleValidator());

--- a/src/main/resources/swing-extras/releaseNotes.txt
+++ b/src/main/resources/swing-extras/releaseNotes.txt
@@ -5,6 +5,7 @@ Version 3.0.0 [TODO - release date] - Major refactoring
   #475 - LongTextProperty: add row limit for dynamic multiline
   #473 - TextInputDialog: allow setting help text for input field
   #472 - TextInputDialog: better resizing of confirm button
+  #471 - TextInputDialog: add optional overview label
   #470 - Make ResourceLoader more flexible with class loaders
   #469 - Minor tweak to ExtensionManager's load order logic
   #467 - Minor javadoc cleanup for form validators


### PR DESCRIPTION
This PR addresses issue #471 by adding an optional "overview" label at the top of the `TextInputDialog`, directly above the text entry field. This default to blank/invisible, to match the previous behavior. If specified, the overview label can be used to provide users with additional context as to what they are supposed to input.

Updated the demo app to show off this new feature.
