### PR TITLE
Issue #466 - New FieldValidator: UrlValidator

### DIFF
--- a/src/main/java/ca/corbett/forms/validators/UrlValidator.java
+++ b/src/main/java/ca/corbett/forms/validators/UrlValidator.java
@@ -1,0 +1,61 @@
+package ca.corbett.forms.validators;
+
+import ca.corbett.forms.fields.ShortTextField;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+/**
+ * A simple FieldValidator that can be attached to any ShortTextField to ensure that the
+ * field's value is either blank or a valid URL. If blank values are not permitted,
+ * you can use the overloaded constructor to disallow them. Blank values are
+ * considered valid by default.
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ * @since swing-extras 3.0
+ */
+public class UrlValidator implements FieldValidator<ShortTextField> {
+
+    public static final String MESSAGE = "Value must be a valid URL";
+
+    private final boolean allowBlank;
+
+    public UrlValidator() {
+        this(true);
+    }
+
+    public UrlValidator(boolean allowBlank) {
+        this.allowBlank = allowBlank;
+    }
+
+    @Override
+    public ValidationResult validate(ShortTextField fieldToValidate) {
+        String currentValue = fieldToValidate.getText() == null ? "" : fieldToValidate.getText().trim();
+        if (currentValue.isEmpty()) {
+            return allowBlank
+                    ? ValidationResult.valid() // blank value is explicitly fine
+                    : ValidationResult.invalid("Value cannot be blank"); // blank value is not fine
+        }
+
+        return isValidUrl(currentValue) ? ValidationResult.valid() : ValidationResult.invalid(MESSAGE);
+    }
+
+    /**
+     * A public convenience method for validating URLs. We defer this validation to
+     * the <code>java.net.URL</code> and <code>java.net.URI</code> classes.
+     *
+     * @param url A URL in string form.
+     * @return true if the URL is well-formed.
+     */
+    public static boolean isValidUrl(String url) {
+        try {
+            URL _ = new URI(url).toURL(); // this will catch both URISyntaxException and MalformedURLException
+            return true;
+        }
+        catch (URISyntaxException | MalformedURLException ignored) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/ca/corbett/forms/validators/UrlValidator.java
+++ b/src/main/java/ca/corbett/forms/validators/UrlValidator.java
@@ -51,7 +51,7 @@ public class UrlValidator implements FieldValidator<ShortTextField> {
      */
     public static boolean isValidUrl(String url) {
         try {
-            URL _ = new URI(url).toURL(); // this will catch both URISyntaxException and MalformedURLException
+            URL ignored = new URI(url).toURL(); // this will catch both URISyntaxException and MalformedURLException
             return true;
         }
         catch (URISyntaxException | MalformedURLException ignored) {

--- a/src/main/resources/swing-extras/releaseNotes.txt
+++ b/src/main/resources/swing-extras/releaseNotes.txt
@@ -9,6 +9,7 @@ Version 3.0.0 [TODO - release date] - Major refactoring
   #470 - Make ResourceLoader more flexible with class loaders
   #469 - Minor tweak to ExtensionManager's load order logic
   #467 - Minor javadoc cleanup for form validators
+  #466 - New FieldValidator: UrlValidator
   #465 - New UI component: AgreementDialog
   #456 - Upgrade all dependency versions to latest
   #455 - Drop support for JTattoo

--- a/src/test/java/ca/corbett/forms/fields/ShortTextFieldTest.java
+++ b/src/test/java/ca/corbett/forms/fields/ShortTextFieldTest.java
@@ -98,6 +98,16 @@ class ShortTextFieldTest extends FormFieldBaseTests {
         assertTrue(urlField.isValid());
         urlField.setText("https://www.github.com");
         assertTrue(urlField.isValid());
+
+        // By default, blank values should be allowed:
+        urlField.setText("");
+        assertTrue(urlField.isValid());
+
+        // But we have the option of disallowing them:
+        ShortTextField urlFieldNoBlank = new ShortTextField("URL", 20);
+        urlFieldNoBlank.addFieldValidator(new UrlValidator(false));
+        urlFieldNoBlank.setText("");
+        assertFalse(urlFieldNoBlank.isValid());
     }
 
     @Test

--- a/src/test/java/ca/corbett/forms/fields/ShortTextFieldTest.java
+++ b/src/test/java/ca/corbett/forms/fields/ShortTextFieldTest.java
@@ -1,6 +1,7 @@
 package ca.corbett.forms.fields;
 
 import ca.corbett.forms.validators.FieldValidator;
+import ca.corbett.forms.validators.UrlValidator;
 import ca.corbett.forms.validators.ValidationResult;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -79,6 +80,24 @@ class ShortTextFieldTest extends FormFieldBaseTests {
         actual.removeValueChangedListener(listener);
         actualField.setText("Hello");
         Mockito.verify(listener, Mockito.times(0)).formFieldValueChanged(actual);
+    }
+
+    @Test
+    public void urlValidatorTests() {
+        ShortTextField urlField = new ShortTextField("URL", 20);
+        urlField.addFieldValidator(new UrlValidator());
+
+        // GIVEN invalid URLs, should fail validation:
+        urlField.setText("Not a url");
+        assertFalse(urlField.isValid());
+        urlField.setText("htttttp://www.yourmomshouse.example");
+        assertFalse(urlField.isValid());
+
+        // GIVEN valid URLs, should pass validation:
+        urlField.setText("ftp://10.0.0.1/file.txt");
+        assertTrue(urlField.isValid());
+        urlField.setText("https://www.github.com");
+        assertTrue(urlField.isValid());
     }
 
     @Test


### PR DESCRIPTION
This PR addresses issue #466 by adding a new `FieldValidator` implementation: `UrlValidator`. This validator can be attached to any `ShortTextField` to provide URL validation on the input. Blank values can be optionally disallowed (they are allowed by default).