### PR TITLE
Issue #488 tighten up maven central publishing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
         <maven.compiler.target>25</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <argLine></argLine> <!-- Needed to keep Surefire happy -->
+        <gpg.skip>true</gpg.skip> <!-- Set to false to enable artifact signing (for Central publishing) -->
     </properties>
 
     <dependencies>
@@ -90,7 +91,7 @@
                     <checksums>all</checksums>
                     <centralBaseUrl>https://central.sonatype.com</centralBaseUrl>
                     <centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots/</centralSnapshotsUrl>
-                    <skipPublishing>false</skipPublishing>
+                    <skipPublishing>true</skipPublishing> <!-- Set to false to enable Central publishing -->
                 </configuration>
             </plugin>
             <plugin>
@@ -154,7 +155,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.6</version>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>
@@ -162,6 +163,9 @@
                         <goals>
                             <goal>sign</goal>
                         </goals>
+                        <configuration>
+                            <skip>${gpg.skip}</skip>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
This PR addresses issue #488 by tightening up the Maven Central publishing options in the `pom.xml` file. Previously, just running a local `mvn install` would prompt for GPG signing credentials, but those are only needed for a Maven Central deploy. 

Due to plugin ordering problems, I can't move it from the `verify` to the `deploy` phase, so instead I've kept it in the `verify` phase but gated it behind a new `gpg.skip` property, which is `true` by default. Now, cloning the repo and doing a `mvn clean install` to get it into your local Maven repo won't bother you for GPG signing credentials. 

Also updated the `mvn-gpg-plugin` version, as it was quite a bit behind.

Also set `skipPublishing` to `true` by default, as that is the safer default option.