### PR TITLE
Issue #490 Fix modal dialog bug on application restart

### DIFF
--- a/src/main/java/ca/corbett/extensions/ui/AvailableExtensionsPanel.java
+++ b/src/main/java/ca/corbett/extensions/ui/AvailableExtensionsPanel.java
@@ -100,6 +100,10 @@ public class AvailableExtensionsPanel extends JPanel {
         initComponents();
     }
 
+    public void setRestartRequired(boolean required) {
+        isRestartRequired = required;
+    }
+
     public boolean isRestartRequired() {
         return isRestartRequired;
     }

--- a/src/main/java/ca/corbett/extensions/ui/AvailableExtensionsPanel.java
+++ b/src/main/java/ca/corbett/extensions/ui/AvailableExtensionsPanel.java
@@ -100,7 +100,7 @@ public class AvailableExtensionsPanel extends JPanel {
         initComponents();
     }
 
-    public void setRestartRequired(boolean required) {
+    void setRestartRequired(boolean required) {
         isRestartRequired = required;
     }
 

--- a/src/main/java/ca/corbett/extensions/ui/ExtensionManagerDialog.java
+++ b/src/main/java/ca/corbett/extensions/ui/ExtensionManagerDialog.java
@@ -133,6 +133,19 @@ public class ExtensionManagerDialog<T extends AppExtension> extends JDialog {
         return wasModified;
     }
 
+    /**
+     * Suppress the "restart required" status flag.
+     * (Invoked by UpdateManager on application restart to avoid redundant "restart required" prompts).
+     */
+    public void setNoRestartRequired() {
+        if (installedExtensionsPanel != null) {
+            installedExtensionsPanel.setRestartRequired(false);
+        }
+        if (availableExtensionsPanel != null) {
+            availableExtensionsPanel.setRestartRequired(false);
+        }
+    }
+
     public boolean isRestartRequired() {
         return (installedExtensionsPanel != null && installedExtensionsPanel.isRestartRequired())
                 || (availableExtensionsPanel != null && availableExtensionsPanel.isRestartRequired());

--- a/src/main/java/ca/corbett/extensions/ui/InstalledExtensionsPanel.java
+++ b/src/main/java/ca/corbett/extensions/ui/InstalledExtensionsPanel.java
@@ -81,7 +81,7 @@ public class InstalledExtensionsPanel<T extends AppExtension> extends JPanel {
         initComponents();
     }
 
-    public void setRestartRequired(boolean required) {
+    void setRestartRequired(boolean required) {
         isRestartRequired = required;
     }
 

--- a/src/main/java/ca/corbett/extensions/ui/InstalledExtensionsPanel.java
+++ b/src/main/java/ca/corbett/extensions/ui/InstalledExtensionsPanel.java
@@ -81,6 +81,10 @@ public class InstalledExtensionsPanel<T extends AppExtension> extends JPanel {
         initComponents();
     }
 
+    public void setRestartRequired(boolean required) {
+        isRestartRequired = required;
+    }
+
     /**
      * Indicates whether any change made on this panel requires an application restart.
      * (Extension uninstalled perhaps).

--- a/src/main/java/ca/corbett/updates/UpdateManager.java
+++ b/src/main/java/ca/corbett/updates/UpdateManager.java
@@ -1,5 +1,6 @@
 package ca.corbett.updates;
 
+import ca.corbett.extensions.ui.ExtensionManagerDialog;
 import ca.corbett.extras.crypt.SignatureUtil;
 import ca.corbett.extras.image.ImageUtil;
 import ca.corbett.extras.io.DownloadAdapter;
@@ -7,6 +8,7 @@ import ca.corbett.extras.io.DownloadManager;
 import ca.corbett.extras.io.DownloadThread;
 import com.google.gson.JsonSyntaxException;
 
+import javax.swing.JDialog;
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 import java.awt.Component;
@@ -407,6 +409,21 @@ public class UpdateManager {
                                           promptText,
                                           "Restart required",
                                           JOptionPane.YES_NO_OPTION) == JOptionPane.YES_OPTION) {
+
+            // If the given parent component is a modal dialog, let's close it before proceeding.
+            // This is important because if there are shutdown hooks registered that need to
+            // show confirmation prompts (unsaved changes or such), then we don't want them to
+            // have to fight against the modality of the dialog we just showed here.
+            if (parent instanceof JDialog && ((JDialog)parent).isModal()) {
+                // If it's our own ExtensionManagerDialog, suppress the "restart required" flag.
+                // This avoids redundant "restart required" prompts when we close it.
+                if (parent instanceof ExtensionManagerDialog<?> extDialog) {
+                    extDialog.setNoRestartRequired();
+                }
+
+                ((JDialog)parent).dispose();
+            }
+
             restartApplication();
         }
     }

--- a/src/main/java/ca/corbett/updates/UpdateManager.java
+++ b/src/main/java/ca/corbett/updates/UpdateManager.java
@@ -414,14 +414,14 @@ public class UpdateManager {
             // This is important because if there are shutdown hooks registered that need to
             // show confirmation prompts (unsaved changes or such), then we don't want them to
             // have to fight against the modality of the dialog we just showed here.
-            if (parent instanceof JDialog && ((JDialog)parent).isModal()) {
+            if (parent instanceof JDialog parentDialog && parentDialog.isModal()) {
                 // If it's our own ExtensionManagerDialog, suppress the "restart required" flag.
                 // This avoids redundant "restart required" prompts when we close it.
-                if (parent instanceof ExtensionManagerDialog<?> extDialog) {
+                if (parentDialog instanceof ExtensionManagerDialog<?> extDialog) {
                     extDialog.setNoRestartRequired();
                 }
 
-                ((JDialog)parent).dispose();
+                parentDialog.dispose();
             }
 
             restartApplication();

--- a/src/main/resources/swing-extras/releaseNotes.txt
+++ b/src/main/resources/swing-extras/releaseNotes.txt
@@ -2,6 +2,7 @@ swing-extras Release Notes
 Author: Steve Corbett
 
 Version 3.0.0 [TODO - release date] - Major refactoring
+  #490 - Fix modal dialog problem on application restart
   #486 - FileWatcher: configurable self-change suppression window
   #475 - LongTextProperty: add row limit for dynamic multiline
   #473 - TextInputDialog: allow setting help text for input field


### PR DESCRIPTION
This PR addresses issue #490 by forcing a close of modal dialogs during application restart, to avoid problems with application shutdown hooks that may want to show dialogs of their own during application shutdown (unsaved changes or such).